### PR TITLE
[MM-27336] Trim Repo Name if SpinWickID is too large

### DIFF
--- a/server/spinwick.go
+++ b/server/spinwick.go
@@ -583,30 +583,14 @@ func checkMMPing(ctx context.Context, client *mattermostModel.Client4) error {
 	}
 }
 
-// Given a string, returns an abbreviation of that string
-// All repositories under the mattermost organization follow a pattern of words-separated-by-dashes (I checked)
-// If there are no '-' characters, the first 4 characters of the repository name are returned to avoid collisions
-func getRepoNameAbbreviation(repoName string) string {
-	abbreviation := ""
-	segments := strings.Split(repoName, "-")
-	for _, segment := range segments {
-		abbreviation = abbreviation + string(segment[0])
-	}
-
-	//If there were no - separators in the repoName, use the first 4 characters
-	if len(abbreviation) == 1 {
-		return repoName[0:4]
-	}
-
-	return abbreviation
-}
-
 func makeSpinWickID(repoName string, prNumber int) string {
 	domainName := ".test.mattermost.cloud"
 	spinWickID := strings.ToLower(fmt.Sprintf("%s-pr-%d", repoName, prNumber))
-	// DNS names in MM cloud have a character limit
-	if len(spinWickID+domainName) > 63 {
-		spinWickID = strings.ToLower(fmt.Sprintf("%s-pr-%d", getRepoNameAbbreviation(repoName), prNumber))
+	// DNS names in MM cloud have a character limit. The number of characters in the domain - 64 will be how many we need to trim
+	numCharactersToTrim := len(spinWickID+domainName) - 64
+	if numCharactersToTrim > 0 {
+		// trim the last numCharactersToTrim characters off of the repoName and overwrite spinWickID
+		spinWickID = strings.ToLower(fmt.Sprintf("%s-pr-%d", repoName[:(len(repoName)-numCharactersToTrim)], prNumber))
 	}
 	return spinWickID
 }

--- a/server/spinwick_test.go
+++ b/server/spinwick_test.go
@@ -33,8 +33,8 @@ func TestMakeSpinWickIDWithLongRepositoryName(t *testing.T) {
 		prNumber int
 		result   string
 	}{
-		{"mattermost-server-webapp-fusion-reactor-test-really-long", 8888, "mswfrtrl"},
-		{"mattermostserverwebappfusionreactortestreallylong", 88, "matt"},
+		{"mattermost-server-webapp-fusion-reactor-test-really-long", 8888, "mattermost-server-webapp-fusion-re"},
+		{"mattermostserverwebappfusionreactortestreallylong", 88, "mattermostserverwebappfusionreactort"},
 	}
 
 	for _, tc := range tests {
@@ -42,6 +42,7 @@ func TestMakeSpinWickIDWithLongRepositoryName(t *testing.T) {
 			id := makeSpinWickID(tc.repoName, tc.prNumber)
 			assert.Contains(t, id, tc.result)
 			assert.Contains(t, id, fmt.Sprintf("%d", tc.prNumber))
+			assert.Equal(t, id, fmt.Sprintf("%s-pr-%d", tc.result, tc.prNumber))
 		})
 	}
 }

--- a/server/spinwick_test.go
+++ b/server/spinwick_test.go
@@ -27,6 +27,25 @@ func TestMakeSpinWickID(t *testing.T) {
 	}
 }
 
+func TestMakeSpinWickIDWithLongRepositoryName(t *testing.T) {
+	tests := []struct {
+		repoName string
+		prNumber int
+		result   string
+	}{
+		{"mattermost-server-webapp-fusion-reactor-test-really-long", 8888, "mswfrtrl"},
+		{"mattermostserverwebappfusionreactortestreallylong", 88, "matt"},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.repoName, func(t *testing.T) {
+			id := makeSpinWickID(tc.repoName, tc.prNumber)
+			assert.Contains(t, id, tc.result)
+			assert.Contains(t, id, fmt.Sprintf("%d", tc.prNumber))
+		})
+	}
+}
+
 func TestIsSpinWickLabel(t *testing.T) {
 	spinwickLabel := "spinwick"
 	spinwickHALabel := "spinwick ha"

--- a/server/spinwick_test.go
+++ b/server/spinwick_test.go
@@ -9,6 +9,15 @@ import (
 )
 
 func TestMakeSpinWickID(t *testing.T) {
+	spinwickLabel := "spinwick"
+	spinwickHALabel := "spinwick ha"
+	s := &Server{
+		Config: &MatterwickConfig{
+			SetupSpinWick:     spinwickLabel,
+			SetupSpinWickHA:   spinwickHALabel,
+			DNSNameTestServer: ".test.mattermost.cloud",
+		},
+	}
 	tests := []struct {
 		repoName string
 		prNumber int
@@ -20,7 +29,7 @@ func TestMakeSpinWickID(t *testing.T) {
 
 	for _, tc := range tests {
 		t.Run(tc.repoName, func(t *testing.T) {
-			id := makeSpinWickID(tc.repoName, tc.prNumber)
+			id := s.makeSpinWickID(tc.repoName, tc.prNumber)
 			assert.Contains(t, id, tc.repoName)
 			assert.Contains(t, id, fmt.Sprintf("%d", tc.prNumber))
 		})
@@ -28,6 +37,15 @@ func TestMakeSpinWickID(t *testing.T) {
 }
 
 func TestMakeSpinWickIDWithLongRepositoryName(t *testing.T) {
+	spinwickLabel := "spinwick"
+	spinwickHALabel := "spinwick ha"
+	s := &Server{
+		Config: &MatterwickConfig{
+			SetupSpinWick:     spinwickLabel,
+			SetupSpinWickHA:   spinwickHALabel,
+			DNSNameTestServer: ".test.mattermost.cloud",
+		},
+	}
 	tests := []struct {
 		repoName string
 		prNumber int
@@ -39,7 +57,7 @@ func TestMakeSpinWickIDWithLongRepositoryName(t *testing.T) {
 
 	for _, tc := range tests {
 		t.Run(tc.repoName, func(t *testing.T) {
-			id := makeSpinWickID(tc.repoName, tc.prNumber)
+			id := s.makeSpinWickID(tc.repoName, tc.prNumber)
 			assert.Contains(t, id, tc.result)
 			assert.Contains(t, id, fmt.Sprintf("%d", tc.prNumber))
 			assert.Equal(t, id, fmt.Sprintf("%s-pr-%d", tc.result, tc.prNumber))


### PR DESCRIPTION
#### Summary
If the repository name was large, and the number of pull requests to said repository was high, it was possible for the DNS name to be too large (greater than 64 characters). This PR adds functionality to trim off of the repository name the number of characters needed to put the DNS name below that threshold. 

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-27336
#### Release Note
```release-note
Repositories with long names will now have their repository names trimmed in their SpinWick URL's.
```
