### PR TITLE
delete namespace but first delete all resources inside

### DIFF
--- a/server/pull_request.go
+++ b/server/pull_request.go
@@ -118,6 +118,8 @@ func (s *Server) removeOldComments(comments []*github.IssueComment, pr *model.Pu
 		"Enterprise Edition Image not available",
 		"CWS test server created!",
 		"Creating a SpinWick test customer web server",
+		"Spinwick CWS test server has been destroyed",
+		"CWS test server updated",
 	}
 
 	mlog.Info("Removing old Matterwick comments")

--- a/server/spinwick.go
+++ b/server/spinwick.go
@@ -644,7 +644,7 @@ func (s *Server) destroyKubeSpinWick(pr *model.PullRequest) *spinwick.Request {
 		return request.WithError(errors.Wrap(err, "unable to get list of old comments")).ShouldReportError()
 	}
 	s.removeOldComments(comments, pr)
-	s.sendGitHubComment(pr.RepoOwner, pr.RepoName, pr.Number, "Spinwick Kubernetes namespace "+namespaceName+" has been destroyed")
+	s.sendGitHubComment(pr.RepoOwner, pr.RepoName, pr.Number, "Spinwick CWS test server has been destroyed.")
 	return request
 }
 


### PR DESCRIPTION
#### Summary
When deleting the test CWS server we need to cascade the resource deletion and not only remove the namespace, we might have some orphan resources around in the cluster.



#### Ticket Link

#### Release Note
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

-->

```release-note
delete namespace but first delete all resources inside
```
