### PR TITLE
cws: change the order to have the secrets created first and add new env var

### DIFF
--- a/config/config-matterwick.default.json
+++ b/config/config-matterwick.default.json
@@ -47,6 +47,7 @@
       "CWSEmailReplyToAddress": "",
       "CWSEmailBCCAddress": "",
       "CWSCloudURL": "",
+      "CWSStripeKey": "",
       "DockerHubCredentials": ""
   }
 }

--- a/server/config.go
+++ b/server/config.go
@@ -27,6 +27,7 @@ type CWS struct {
 	CWSEmailReplyToAddress    string
 	CWSEmailBCCAddress        string
 	CWSCloudURL               string
+	CWSStripeKey              string
 	DockerHubCredentials      string
 }
 

--- a/templates/cws/cws_deployment.tmpl
+++ b/templates/cws/cws_deployment.tmpl
@@ -1,3 +1,37 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: customer-web-server-secret
+  namespace: {{ .Namespace }}
+type: Opaque
+stringData:
+  DATABASE: {{ .Environment.Database }}
+  CWS_PAYMENT_URL: {{ .Environment.CWSPaymentURL }}
+  CWS_PAYMENT_TOKEN: {{ .Environment.CWSPaymentToken }}
+  CWS_SITEURL: {{ .Environment.CWSSiteURL }}
+  CWS_SMTP_USERNAME: {{ .Environment.CWSSMTPUsername }}
+  CWS_SMTP_PASSWORD: {{ .Environment.CWSSMTPPassword }}
+  CWS_SMTP_SERVER: {{ .Environment.CWSSMTPServer }}
+  CWS_SMTP_PORT: "{{ .Environment.CWSSMTPPort }}"
+  CWS_SMTP_SERVERTIMEOUT: "{{ .Environment.CWSSMTPServerTimeout }}"
+  CWS_SMTP_CONNECTIONSECURITY: {{ .Environment.CWSSMTPConnectionSecurity }}
+  CWS_EMAIL_REPLYTONAME: {{ .Environment.CWSEmailReplyToName }}
+  CWS_EMAIL_REPLYTOADDRESS: {{ .Environment.CWSEmailReplyToAddress }}
+  CWS_EMAIL_BCCADDRESSES: {{ .Environment.CWSEmailBCCAddress }}
+  CWS_CLOUD_URL: {{ .Environment.CWSCloudURL }}
+  CWS_STRIPE_KEY: {{ .Environment.CWSStripeKey }}
+
+---
+apiVersion: v1
+data:
+  .dockerconfigjson: {{ .Environment.DockerHubCredentials }}
+kind: Secret
+metadata:
+  name: customer-web-server-gitlab-image
+  namespace: {{ .Namespace }}
+type: kubernetes.io/dockerconfigjson
+
+---
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -31,7 +65,7 @@ spec:
         - secretRef:
             name: customer-web-server-secret
         image: mattermost/cws-test:{{ .ImageTag }}
-        imagePullPolicy: Always
+        imagePullPolicy: IfNotPresent
         name: cws-main
         ports:
         - containerPort: 8076
@@ -53,40 +87,10 @@ spec:
         - secretRef:
             name: customer-web-server-secret
         image: mattermost/cws-test:{{ .ImageTag }}
-        imagePullPolicy: Always
+        imagePullPolicy: IfNotPresent
         name: customer-web-server-init-database
       restartPolicy: Always
----
-apiVersion: v1
-kind: Secret
-metadata:
-  name: customer-web-server-secret
-  namespace: {{ .Namespace }}
-type: Opaque
-stringData:
-  DATABASE: {{ .Environment.Database }}
-  CWS_PAYMENT_URL: {{ .Environment.CWSPaymentURL }}
-  CWS_PAYMENT_TOKEN: {{ .Environment.CWSPaymentToken }}
-  CWS_SITEURL: {{ .Environment.CWSSiteURL }}
-  CWS_SMTP_USERNAME: {{ .Environment.CWSSMTPUsername }}
-  CWS_SMTP_PASSWORD: {{ .Environment.CWSSMTPPassword }}
-  CWS_SMTP_SERVER: {{ .Environment.CWSSMTPServer }}
-  CWS_SMTP_PORT: "{{ .Environment.CWSSMTPPort }}"
-  CWS_SMTP_SERVERTIMEOUT: "{{ .Environment.CWSSMTPServerTimeout }}"
-  CWS_SMTP_CONNECTIONSECURITY: {{ .Environment.CWSSMTPConnectionSecurity }}
-  CWS_EMAIL_REPLYTONAME: {{ .Environment.CWSEmailReplyToName }}
-  CWS_EMAIL_REPLYTOADDRESS: {{ .Environment.CWSEmailReplyToAddress }}
-  CWS_EMAIL_BCCADDRESSES: {{ .Environment.CWSEmailBCCAddress }}
-  CWS_CLOUD_URL: {{ .Environment.CWSCloudURL }}
----
-apiVersion: v1
-data:
-  .dockerconfigjson: {{ .Environment.DockerHubCredentials }}
-kind: Secret
-metadata:
-  name: customer-web-server-gitlab-image
-  namespace: {{ .Namespace }}
-type: kubernetes.io/dockerconfigjson
+
 ---
 apiVersion: v1
 kind: ConfigMap


### PR DESCRIPTION
#### Summary
- Change the order to create the objects and make the secret to be created first so no errors related to pulling the image will happen
- also added a new variable, already added in the config


#### Ticket Link
<!--
If this pull request addresses a Help Wanted ticket, please link the relevant GitHub issue, e.g.

  Fixes https://github.com/mattermost/mattermost-server/issues/XXXXX

Otherwise, link the JIRA ticket.
-->

#### Release Note
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

-->

```release-note
NONE
```
