### PR TITLE
Add new environment variables for CWS license generation

### DIFF
--- a/config/config-matterwick.default.json
+++ b/config/config-matterwick.default.json
@@ -49,6 +49,8 @@
       "CWSCloudURL": "",
       "CWSStripeKey": "",
       "CWSCloudDNSDomain": "",
+      "CWS_LICENSE_GENERATOR_URL": "",
+      "CWS_LICENSE_GENERATOR_KEY": "",
       "DockerHubCredentials": ""
   }
 }

--- a/server/config.go
+++ b/server/config.go
@@ -29,6 +29,8 @@ type CWS struct {
 	CWSCloudURL               string
 	CWSStripeKey              string
 	CWSCloudDNSDomain         string
+	CWSLicenseGeneratorURL    string
+	CWSLicenseGeneratorKey    string
 	DockerHubCredentials      string
 }
 

--- a/templates/cws/cws_deployment.tmpl
+++ b/templates/cws/cws_deployment.tmpl
@@ -21,6 +21,8 @@ stringData:
   CWS_CLOUD_URL: {{ .Environment.CWSCloudURL }}
   CWS_CLOUD_DNS_DOMAIN: {{ .Environment.CWSCloudDNSDomain }}
   CWS_STRIPE_KEY: {{ .Environment.CWSStripeKey }}
+  CWS_LICENSE_GENERATOR_URL: {{ .Environment.CWSLicenseGeneratorURL }}
+  CWS_LICENSE_GENERATOR_KEY: {{ .Environment.CWSLicenseGeneratorKey }}
 
 ---
 apiVersion: v1


### PR DESCRIPTION
<!-- Thank you for contributing a pull request! Here are a few tips to help you:

1. If this is your first contribution, make sure you've read the Contribution Checklist https://developers.mattermost.com/contribute/getting-started/contribution-checklist/
2. Read our blog post about "Submitting Great PRs" https://developers.mattermost.com/blog/2019-01-24-submitting-great-prs
3. Take a look at other repository specific documentation at https://developers.mattermost.com/contribute
-->

#### Summary
<!--
A description of what this pull request does.
-->
Adds variables for license generation environment variables for the CWS to the Matterwick configuration, re: https://github.com/mattermost/customer-web-server/pull/149#issuecomment-680001188

Please let me know if I've done this incorrectly.


<!--
If this pull request addresses a Help Wanted ticket, please link the relevant GitHub issue, e.g.

  Fixes https://github.com/mattermost/mattermost-server/issues/XXXXX

Otherwise, link the JIRA ticket.
-->

#### Release Note
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

-->

```release-note
Added configuration for license generation from CWS created by Matterwick
```
