### PR TITLE
Adding CWSCloudBetaCode

### DIFF
--- a/config/config-matterwick.default.json
+++ b/config/config-matterwick.default.json
@@ -37,6 +37,7 @@
       "CWSPaymentURL": "",
       "CWSPaymentToken": "",
       "CWSSiteURL": "",
+      "CWSCloudBetaCode": "",
       "CWSSMTPUsername": "",
       "CWSSMTPPassword": "",
       "CWSSMTPServer": "",

--- a/server/config.go
+++ b/server/config.go
@@ -17,6 +17,7 @@ type CWS struct {
 	CWSPaymentURL             string
 	CWSPaymentToken           string
 	CWSSiteURL                string
+	CWSCloudBetaCode          string
 	CWSSMTPUsername           string
 	CWSSMTPPassword           string
 	CWSSMTPServer             string

--- a/templates/cws/cws_deployment.tmpl
+++ b/templates/cws/cws_deployment.tmpl
@@ -9,6 +9,7 @@ stringData:
   CWS_PAYMENT_URL: {{ .Environment.CWSPaymentURL }}
   CWS_PAYMENT_TOKEN: {{ .Environment.CWSPaymentToken }}
   CWS_SITEURL: {{ .Environment.CWSSiteURL }}
+  CWS_CLOUD_BETACODE: {{ .Environment.CWSCloudBetaCode }}
   CWS_SMTP_USERNAME: {{ .Environment.CWSSMTPUsername }}
   CWS_SMTP_PASSWORD: {{ .Environment.CWSSMTPPassword }}
   CWS_SMTP_SERVER: {{ .Environment.CWSSMTPServer }}


### PR DESCRIPTION
#### Summary
Adding CWSCloudBetaCode (corresponding CWS change: https://github.com/mattermost/customer-web-server/pull/178)

```release-note
Add CWS Cloud BetaCode configuration for CWS that limits who can sign-up for the Cloud beta
```
