### PR TITLE
fix PV when terminating and cws test server

### DIFF
--- a/server/spinwick.go
+++ b/server/spinwick.go
@@ -131,7 +131,6 @@ func (s *Server) createKubeSpinWick(pr *model.PullRequest) *spinwick.Request {
 	deployment := Deployment{
 		Namespace:      namespace.GetName(),
 		ImageTag:       version,
-		PR:             pr.Number,
 		DeployFilePath: "/tmp/cws_deployment" + namespace.GetName() + ".yaml",
 		Environment:    s.Config.CWS,
 	}

--- a/templates/cws/cws_deployment.tmpl
+++ b/templates/cws/cws_deployment.tmpl
@@ -108,24 +108,6 @@ data:
   POSTGRES_USER: xcws
   POSTGRES_PASSWORD: xcws!934XCWS
 ---
-kind: PersistentVolume
-apiVersion: v1
-metadata:
-  name: postgres-pv-volume-{{ .PR }}
-  labels:
-    type: local
-    app: postgres
-spec:
-  storageClassName: gp2
-  persistentVolumeReclaimPolicy: Delete
-  capacity:
-    storage: 1Gi
-  accessModes:
-    - ReadWriteMany
-  hostPath:
-    path: "/mnt/data"
-
----
 kind: PersistentVolumeClaim
 apiVersion: v1
 metadata:
@@ -136,7 +118,7 @@ metadata:
 spec:
   storageClassName: gp2
   accessModes:
-    - ReadWriteMany
+    - ReadWriteOnce
   resources:
     requests:
       storage: 1Gi
@@ -172,7 +154,7 @@ spec:
             - configMapRef:
                 name: postgres-config
           volumeMounts:
-            - mountPath: /var/lib/postgresql/data
+            - mountPath: /cws/postgresql
               name: postgredb
       volumes:
         - name: postgredb


### PR DESCRIPTION
#### Summary
When terminating a CWS test server sometime the PV get in a failed state and is not removed, this PR fix that


#### Ticket Link
NONE


#### Release Note
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

-->

```release-note
NONE
```
