### PR TITLE
Added CWS_DISABLE_RENEWAL_CHECKS env var to CWS 

### DIFF
--- a/config/config-matterwick.default.json
+++ b/config/config-matterwick.default.json
@@ -56,6 +56,7 @@
       "CWSBlapiToken": "",
       "CWSLicenseGeneratorUrl": "",
       "CWSLicenseGeneratorKey": "",
+      "CWSDisableRenewalChecks": "",
       "DockerHubCredentials": ""
   }
 }

--- a/server/config.go
+++ b/server/config.go
@@ -32,6 +32,7 @@ type CWS struct {
 	CWSBlapiToken             string
 	CWSLicenseGeneratorURL    string
 	CWSLicenseGeneratorKey    string
+	CWSDisableRenewalChecks   string
 	DockerHubCredentials      string
 }
 

--- a/templates/cws/cws_deployment.tmpl
+++ b/templates/cws/cws_deployment.tmpl
@@ -24,6 +24,7 @@ stringData:
   CWS_STRIPE_KEY: {{ .Environment.CWSStripeKey }}
   CWS_LICENSE_GENERATOR_URL: {{ .Environment.CWSLicenseGeneratorURL }}
   CWS_LICENSE_GENERATOR_KEY: {{ .Environment.CWSLicenseGeneratorKey }}
+  CWS_DISABLE_RENEWAL_CHECKS: {{ .Environment.CWSDisableRenewalChecks }}
 
 ---
 apiVersion: v1


### PR DESCRIPTION
#### Summary

Added `CWS_DISABLE_RENEWAL_CHECKS` env var to CWS spinwick deployments. 

```release-note
NONE
```
