### PR TITLE
Wrap CWSDisableRenewalChecks in quotes

### DIFF
--- a/templates/cws/cws_deployment.tmpl
+++ b/templates/cws/cws_deployment.tmpl
@@ -24,7 +24,7 @@ stringData:
   CWS_STRIPE_KEY: {{ .Environment.CWSStripeKey }}
   CWS_LICENSE_GENERATOR_URL: {{ .Environment.CWSLicenseGeneratorURL }}
   CWS_LICENSE_GENERATOR_KEY: {{ .Environment.CWSLicenseGeneratorKey }}
-  CWS_DISABLE_RENEWAL_CHECKS: {{ .Environment.CWSDisableRenewalChecks }}
+  CWS_DISABLE_RENEWAL_CHECKS: "{{ .Environment.CWSDisableRenewalChecks }}"
 
 ---
 apiVersion: v1


### PR DESCRIPTION
#### Summary
Matterwick has been throwing `encountered 1 failures trying to update resources` errors today for CWS spinwicks. I believe this is because the string value `true` is being placed in the template file, but the yaml parser sees that as boolean `true` and not string `"true"`, preventing the apply from happening.

Wrapping in quotes should fix this issue.

#### Ticket Link
n/a
#### Release Note
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

-->

```release-note
None
```
