### PR TITLE
[MM-19541] Automatically install plugin for plugin repo PRs

### DIFF
--- a/server/plugins.go
+++ b/server/plugins.go
@@ -1,0 +1,162 @@
+package server
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io/ioutil"
+	"net/http"
+	"strings"
+
+	"github.com/google/go-github/v32/github"
+	"github.com/mattermost/mattermost-server/v5/mlog"
+	mattermostModel "github.com/mattermost/mattermost-server/v5/model"
+	"github.com/pkg/errors"
+
+	"github.com/mattermost/matterwick/model"
+)
+
+func (s *Server) uploadPluginIfNecessary(mmClient *mattermostModel.Client4, pr *model.PullRequest) error {
+	if !strings.HasPrefix(pr.RepoName, "mattermost-plugin-") || pr.RepoName == "mattermost-plugin-api" {
+		return nil
+	}
+
+	mlog.Debug("Preparing to upload plugin to the SpinWick server")
+	mlog.Debug("Getting CI check information")
+
+	gh := github.NewClient(nil)
+	checkName := "ci"
+	checks, _, err := gh.Checks.ListCheckRunsForRef(context.Background(), pr.RepoOwner, pr.RepoName, pr.Sha, &github.ListCheckRunsOptions{CheckName: &checkName})
+	if err != nil {
+		return err
+	}
+
+	if len(checks.CheckRuns) == 0 {
+		return errors.New("checks.CheckRuns has len 0")
+	}
+
+	run := *checks.CheckRuns[0].ExternalID
+	workflowData := map[string]string{}
+	err = json.Unmarshal([]byte(run), &workflowData)
+	if err != nil {
+		return err
+	}
+
+	mlog.Debug("Getting artifacts URL")
+
+	workflowID := workflowData["workflow-id"]
+	artifactURL, err := getArtifactURLForJob(workflowID, "plugin-ci/build")
+	if err != nil {
+		return err
+	}
+
+	mlog.Debug("Installing plugin artifact from " + artifactURL)
+
+	m, response := mmClient.InstallPluginFromUrl(artifactURL, true)
+	if response.Error != nil {
+		return response.Error
+	}
+
+	if m == nil {
+		return errors.New("manifest is nil")
+	}
+
+	mlog.Debug("Enabling plugin")
+
+	_, response = mmClient.EnablePlugin(m.Id)
+	if response.Error != nil {
+		return response.Error
+	}
+
+	// do other initialization stuff per https://mattermost.atlassian.net/browse/MM-19546
+
+	return nil
+}
+
+func getArtifactURLForJob(workflowID, jobName string) (string, error) {
+	u := fmt.Sprintf("https://circleci.com/api/v2/workflow/%v/job", workflowID)
+	req, err := http.NewRequest(http.MethodGet, u, nil)
+	if err != nil {
+		return "", err
+	}
+
+	res, err := http.DefaultClient.Do(req)
+	if err != nil {
+		return "", err
+	}
+
+	defer res.Body.Close()
+
+	b, err := ioutil.ReadAll(res.Body)
+	if err != nil {
+		return "", err
+	}
+
+	type JobsResponse struct {
+		Items []struct {
+			ID          string `json:"id"`
+			Name        string `json:"name"`
+			ProjectSlug string `json:"project_slug"`
+			JobNumber   int    `json:"job_number"`
+		} `json:"items"`
+	}
+
+	jobs := &JobsResponse{}
+	err = json.Unmarshal(b, jobs)
+	if err != nil {
+		return "", err
+	}
+
+	num := 0
+	slug := ""
+	for _, j := range jobs.Items {
+		if j.Name == jobName {
+			num = j.JobNumber
+			slug = j.ProjectSlug
+			break
+		}
+	}
+
+	if slug == "" {
+		return "", fmt.Errorf("no job found for name %s", jobName)
+	}
+
+	u = fmt.Sprintf("https://circleci.com/api/v2/project/%v/%v/artifacts", slug, num)
+	req, err = http.NewRequest(http.MethodGet, u, nil)
+	if err != nil {
+		return "", err
+	}
+
+	res, err = http.DefaultClient.Do(req)
+	if err != nil {
+		return "", err
+	}
+
+	defer res.Body.Close()
+
+	b, err = ioutil.ReadAll(res.Body)
+	if err != nil {
+		return "", err
+	}
+
+	type ArtifactsResponse struct {
+		Items []struct {
+			Path string `json:"path"`
+			URL  string `json:"url"`
+		} `json:"items"`
+	}
+
+	artifacts := &ArtifactsResponse{}
+	err = json.Unmarshal(b, artifacts)
+	if err != nil {
+		return "", err
+	}
+
+	for _, a := range artifacts.Items {
+		if strings.HasSuffix(a.Path, "tar.gz") {
+			return a.URL, nil
+		}
+	}
+
+	return "", errors.New("couldn't find artifact")
+}

--- a/server/plugins.go
+++ b/server/plugins.go
@@ -45,7 +45,13 @@ func (s *Server) uploadPluginIfNecessary(mmClient *mattermostModel.Client4, pr *
 	mlog.Debug("Getting artifacts URL")
 
 	workflowID := workflowData["workflow-id"]
-	artifactURL, err := getArtifactURLForJob(workflowID, "plugin-ci/build")
+
+	jobName := "plugin-ci/build"
+	if pr.RepoName == "mattermost-plugin-playbooks" {
+		jobName = "build"
+	}
+
+	artifactURL, err := getArtifactURLForJob(workflowID, jobName)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
#### Summary

This PR makes it so when a SpinWick server is created through a label on a plugin repo's PR, the built plugin is automatically installed onto the server. Since `PluginSettings.EnableUploads` is disabled for servers created from a pull request, we'll need a way to have it enabled during the initial server setup. I'm thinking the config value is being set by an environment variable, so this may require a server restart.

#### Ticket Link

Fixes https://mattermost.atlassian.net/browse/MM-19541

#### Release Note
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

-->

```release-note
When a SpinWick server is created through a label on a plugin repo's PR, the plugin built by circleci is automatically installed onto the server.
```
