### PR TITLE
Use default annotation for Installations

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -39,3 +39,5 @@ Session.vim
 
 .agignore
 /config/config-matterwick.json
+
+/.idea

--- a/server/spinwick.go
+++ b/server/spinwick.go
@@ -38,6 +38,8 @@ const (
 	mattermostTeamImage  = "mattermost/mm-te-test"
 	mattermostWebAppRepo = "mattermost-webapp"
 	mattermostServerRepo = "mattermost-server"
+
+	defaultMultiTenantAnnotation = "multi-tenant"
 )
 
 func (s *Server) handleCreateSpinWick(pr *model.PullRequest, size string, withLicense bool, withCloudInfra bool) {
@@ -395,14 +397,15 @@ func (s *Server) createSpinWick(pr *model.PullRequest, size string, withLicense 
 	// }
 
 	installationRequest := &cloudModel.CreateInstallationRequest{
-		OwnerID:   ownerID,
-		Version:   version,
-		Image:     image,
-		DNS:       fmt.Sprintf("%s.%s", ownerID, s.Config.DNSNameTestServer),
-		Size:      size,
-		Affinity:  "multitenant",
-		Database:  cloudModel.InstallationDatabaseMultiTenantRDSPostgresPGBouncer,
-		Filestore: cloudModel.InstallationFilestoreAwsS3,
+		OwnerID:     ownerID,
+		Version:     version,
+		Image:       image,
+		DNS:         fmt.Sprintf("%s.%s", ownerID, s.Config.DNSNameTestServer),
+		Size:        size,
+		Affinity:    "multitenant",
+		Database:    cloudModel.InstallationDatabaseMultiTenantRDSPostgresPGBouncer,
+		Filestore:   cloudModel.InstallationFilestoreAwsS3,
+		Annotations: []string{defaultMultiTenantAnnotation},
 	}
 	if withLicense {
 		installationRequest.License = s.Config.SpinWickHALicense


### PR DESCRIPTION
<!-- Thank you for contributing a pull request! Here are a few tips to help you:

1. If this is your first contribution, make sure you've read the Contribution Checklist https://developers.mattermost.com/contribute/getting-started/contribution-checklist/
2. Read our blog post about "Submitting Great PRs" https://developers.mattermost.com/blog/2019-01-24-submitting-great-prs
3. Take a look at other repository specific documentation at https://developers.mattermost.com/contribute
-->

#### Summary
<!--
A description of what this pull request does.
-->
Use multi-tenant annotation for Spinwicks so that they are not scheduled on e2e tests clusters.

#### Ticket Link
<!--
If this pull request addresses a Help Wanted ticket, please link the relevant GitHub issue, e.g.

  Fixes https://github.com/mattermost/mattermost-server/issues/XXXXX

Otherwise, link the JIRA ticket.
-->

#### Release Note
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

-->

```release-note
Use default annotation for Installations
```
