### PR TITLE
Support Split FFs and Freemium in CWS Spinwicks

### DIFF
--- a/config/config-matterwick.default.json
+++ b/config/config-matterwick.default.json
@@ -57,6 +57,10 @@
       "CWSLicenseGeneratorUrl": "",
       "CWSLicenseGeneratorKey": "",
       "CWSDisableRenewalChecks": "",
-      "DockerHubCredentials": ""
+      "DockerHubCredentials": "",
+      "CWSSplitKey": "",
+      "CWSSplitServerID": "",
+      "CloudDefaultProductID": "",
+      "CloudDefaultTrialProductID": ""
   }
 }

--- a/server/config.go
+++ b/server/config.go
@@ -13,27 +13,31 @@ import (
 
 // CWS contains all configuration for the Customer Web Server
 type CWS struct {
-	Database                  string
-	CWSSiteURL                string
-	CWSSMTPUsername           string
-	CWSSMTPPassword           string
-	CWSSMTPServer             string
-	CWSSMTPPort               string
-	CWSSMTPServerTimeout      string
-	CWSSMTPConnectionSecurity string
-	CWSEmailReplyToName       string
-	CWSEmailReplyToAddress    string
-	CWSEmailBCCAddress        string
-	CWSCloudURL               string
-	CWSStripeKey              string
-	CWSCloudDNSDomain         string
-	CWSCloudGroupID           string
-	CWSBlapiURL               string
-	CWSBlapiToken             string
-	CWSLicenseGeneratorURL    string
-	CWSLicenseGeneratorKey    string
-	CWSDisableRenewalChecks   string
-	DockerHubCredentials      string
+	Database                   string
+	CWSSiteURL                 string
+	CWSSMTPUsername            string
+	CWSSMTPPassword            string
+	CWSSMTPServer              string
+	CWSSMTPPort                string
+	CWSSMTPServerTimeout       string
+	CWSSMTPConnectionSecurity  string
+	CWSEmailReplyToName        string
+	CWSEmailReplyToAddress     string
+	CWSEmailBCCAddress         string
+	CWSCloudURL                string
+	CWSStripeKey               string
+	CWSCloudDNSDomain          string
+	CWSCloudGroupID            string
+	CWSBlapiURL                string
+	CWSBlapiToken              string
+	CWSLicenseGeneratorURL     string
+	CWSLicenseGeneratorKey     string
+	CWSDisableRenewalChecks    string
+	CWSSplitKey                string
+	CWSSplitServerID           string
+	CloudDefaultProductID      string
+	CloudDefaultTrialProductID string
+	DockerHubCredentials       string
 }
 
 // MatterwickConfig defines all config for to run the server

--- a/server/spinwick.go
+++ b/server/spinwick.go
@@ -286,7 +286,7 @@ func (s *Server) createCWSSpinWick(pr *model.PullRequest) *spinwick.Request {
 	}
 
 	spinwickURL := fmt.Sprintf("http://%s", lbURL)
-	msg := fmt.Sprintf("CWS test server created! :tada:\n\nAccess here: %s\n\nSplit Server ID: %s", spinwickURL, deployment.Environment.CWSSplitServerID)
+	msg := fmt.Sprintf("CWS test server created! :tada:\n\nAccess here: %s\n\nSplit individual target: %s", spinwickURL, deployment.Environment.CWSSplitServerID)
 	s.sendGitHubComment(pr.RepoOwner, pr.RepoName, pr.Number, msg)
 
 	request.InstallationID = deployment.Namespace

--- a/server/spinwick.go
+++ b/server/spinwick.go
@@ -286,7 +286,7 @@ func (s *Server) createCWSSpinWick(pr *model.PullRequest) *spinwick.Request {
 	}
 
 	spinwickURL := fmt.Sprintf("http://%s", lbURL)
-	msg := fmt.Sprintf("CWS test server created! :tada:\n\nAccess here: %s\n\n", spinwickURL)
+	msg := fmt.Sprintf("CWS test server created! :tada:\n\nAccess here: %s\n\nSplit Server ID: %s", spinwickURL, deployment.Environment.CWSSplitServerID)
 	s.sendGitHubComment(pr.RepoOwner, pr.RepoName, pr.Number, msg)
 
 	request.InstallationID = deployment.Namespace

--- a/server/spinwick.go
+++ b/server/spinwick.go
@@ -243,6 +243,8 @@ func (s *Server) createCWSSpinWick(pr *model.PullRequest) *spinwick.Request {
 		Environment:    s.Config.CWS,
 	}
 
+	deployment.Environment.CWSSplitServerID = namespace.GetName()
+
 	template, err := template.ParseFiles("/matterwick/templates/cws/cws_deployment.tmpl")
 	if err != nil {
 		mlog.Error("Error loading deployment template ", mlog.Err(err))

--- a/templates/cws/cws_deployment.tmpl
+++ b/templates/cws/cws_deployment.tmpl
@@ -25,6 +25,10 @@ stringData:
   CWS_LICENSE_GENERATOR_URL: {{ .Environment.CWSLicenseGeneratorURL }}
   CWS_LICENSE_GENERATOR_KEY: {{ .Environment.CWSLicenseGeneratorKey }}
   CWS_DISABLE_RENEWAL_CHECKS: "{{ .Environment.CWSDisableRenewalChecks }}"
+  CWS_SPLIT_KEY: "{{ .Environment.CWSSplitKey }}"
+  CWS_SPLIT_SERVER_ID: "{{ .Environment.CWSSplitServerID }}"
+  CLOUD_DEFAULT_PRODUCT_ID: "{{ .Environment.CloudDefaultProductID }}"
+  CLOUD_DEFAULT_TRIAL_PRODUCT_ID: "{{ .Environment.CloudDefaultTrialProductID }}"
 
 ---
 apiVersion: v1


### PR DESCRIPTION
#### Summary
This PR does 2 things:

1. Adds support for Freemium, through the `CLOUD_DEFAULT_PRODUCT_ID` and `CLOUD_DEFAULT_TRIAL_PRODUCT_ID` env variables.
2. Adds support for Split.io out of the box. Spinwicks will be created with a split server ID equivalent to namespace name (I've added this to the output comment for easy reference)

#### Ticket Link
N/a
#### Release Note
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

-->

```release-note
None
```
