### PR TITLE
CWS: Fix patch type

### DIFF
--- a/server/spinwick.go
+++ b/server/spinwick.go
@@ -297,7 +297,7 @@ func (s *Server) createCWSSpinWick(pr *model.PullRequest) *spinwick.Request {
 		_, err := kc.Clientset.AppsV1().Deployments(namespaceName).Patch(
 			ctx,
 			cwsDeploymentName,
-			types.MergePatchType,
+			types.JSONPatchType,
 			[]byte(`[{"op":"add","path":"/spec/template/metadata/labels/date","value":"`+time.Now().Format(time.RFC3339)+`"}]`),
 			metav1.PatchOptions{},
 		)


### PR DESCRIPTION
#### Summary
Fixes a non-blocking bug introduced in #35

Context: we needed to update a secret after AWS gives us the address for the spinwick, and because the secret is not "mounted" in the pods as a volume but use as environment variables we need to patch the deployment by adding a date metadata just to force the deployment to create new pod.

The first patch (changing the secret) works fine but the second part (patching the deployment) fails because I used the wrong type of patch strategy 🤦🏻 This PR fixes this by using a `json` patch instead of a `merge` patch.

#### Ticket Link
N/A

#### Release Note
```release-note
NONE
```
