### PR TITLE
Change default log level to DEBUG

### DIFF
--- a/config/config-matterwick.default.json
+++ b/config/config-matterwick.default.json
@@ -27,7 +27,7 @@
     "ConsoleLevel": "DEBUG",
     "ConsoleJSON": true,
     "EnableFile": false,
-    "FileLevel": "INFO",
+    "FileLevel": "DEBUG",
     "FileJSON": true,
     "FileFormat": "",
     "FileLocation": ""


### PR DESCRIPTION
#### Summary

Setting the log level to debug is always a crucial step to debugging something on a cloud test server. Setting it to `DEBUG` by default would help avoid human error of forgetting to set this value before debugging something. I'm thinking the benefit of this outweighs any benefit we would get for less activity of logging due to setting to `INFO`.

#### Release Note
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

-->

```release-note
NONE
```
