### PR TITLE
[MM-49339] Add support for CWS API Key to authenticate internal API requests

### DIFF
--- a/config/config-matterwick.default.json
+++ b/config/config-matterwick.default.json
@@ -34,6 +34,7 @@
   },
   "CWSPublicAPIAddress": "",
   "CWSInternalAPIAddress": "",
+  "CWSAPIKey": "",
   "CWSUserPassword": "",
   "CWSSpinwickGroupID": "",
   "CWS": {

--- a/server/config.go
+++ b/server/config.go
@@ -86,6 +86,7 @@ type MatterwickConfig struct {
 
 	CWSPublicAPIAddress   string
 	CWSInternalAPIAddress string
+	CWSAPIKey             string
 	CWSUserPassword       string
 	CWSSpinwickGroupID    string
 

--- a/server/spinwick.go
+++ b/server/spinwick.go
@@ -129,7 +129,7 @@ func (s *Server) createCloudSpinWickWithCWS(pr *model.PullRequest, size string) 
 	// We try to login with an existing account and get the customer ID to create the installation
 	// if there isn't an existing user, we create a new one
 	var customerID string
-	cwsClient := cws.NewClient(s.Config.CWSPublicAPIAddress, s.Config.CWSInternalAPIAddress)
+	cwsClient := cws.NewClient(s.Config.CWSPublicAPIAddress, s.Config.CWSInternalAPIAddress, s.Config.CWSAPIKey)
 	_, err := cwsClient.Login(username, password)
 	if err != nil {
 		response, err := cwsClient.SignUp(username, password)
@@ -819,7 +819,7 @@ func (s *Server) destroyCloudSpinWickWithCWS(pr *model.PullRequest) *spinwick.Re
 	username := fmt.Sprintf("user-%s@example.mattermost.com", uniqueID)
 	password := s.Config.CWSUserPassword
 
-	cwsClient := cws.NewClient(s.Config.CWSPublicAPIAddress, s.Config.CWSInternalAPIAddress)
+	cwsClient := cws.NewClient(s.Config.CWSPublicAPIAddress, s.Config.CWSInternalAPIAddress, s.Config.CWSAPIKey)
 	_, err := cwsClient.Login(username, password)
 	if err != nil {
 		return request.WithError(errors.Wrap(err, "error trying to login in the public CWS server")).ShouldReportError()
@@ -1111,7 +1111,7 @@ func (s *Server) makeSpinWickID(repoName string, prNumber int) string {
 }
 
 func (s *Server) getCustomerIDFromCWS(repoName string, prNumber int) (string, error) {
-	cwsClient := cws.NewClient(s.Config.CWSPublicAPIAddress, s.Config.CWSInternalAPIAddress)
+	cwsClient := cws.NewClient(s.Config.CWSPublicAPIAddress, s.Config.CWSInternalAPIAddress, s.Config.CWSAPIKey)
 	uniqueID := s.makeSpinWickID(repoName, prNumber)
 	_, err := cwsClient.Login(
 		fmt.Sprintf("user-%s@example.mattermost.com", uniqueID),


### PR DESCRIPTION
#### Summary
Adds a new config value CWSAPIKey that is the value of the X-MM-Api-Key header passed to CWS for internal API requests. 

See: https://github.com/mattermost/customer-web-server/pull/1044
#### Ticket Link
https://mattermost.atlassian.net/browse/MM-49339

#### Release Note
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

-->

```release-note
None
```
