### PR TITLE
Fix docker push CI/CD workflow

### DIFF
--- a/.github/workflows/image-push.yml
+++ b/.github/workflows/image-push.yml
@@ -17,19 +17,19 @@ jobs:
 
     - uses: actions/checkout@v2
     - name: build-push-tag
-      uses: docker/build-push-action@v1
+      uses: docker/build-push-action@v3
       with:
-        username: ${{ secrets.DOCKER_USERNAME }}
-        password: ${{ secrets.DOCKER_PASSWORD }}
+        username: ${{ secrets.DOCKERHUB_USERNAME }}
+        password: ${{ secrets.DOCKERHUB_TOKEN }}
         repository: mattermost/matterwick
         tag_with_ref: true
         push: ${{ startsWith(github.ref, 'refs/tags/') }}
 
     - name: build-push-master
-      uses: docker/build-push-action@v1
+      uses: docker/build-push-action@v3
       with:
-        username: ${{ secrets.DOCKER_USERNAME }}
-        password: ${{ secrets.DOCKER_PASSWORD }}
+        username: ${{ secrets.DOCKERHUB_USERNAME }}
+        password: ${{ secrets.DOCKERHUB_TOKEN }}
         repository: mattermost/matterwick
         tag_with_ref: true
         push: ${{ startsWith(github.ref, 'refs/heads/master') }}


### PR DESCRIPTION
Changed the docker push workflow to use the correct credentials.

```release-note
None
```
