### PR TITLE
[WIP] Sister PR/Spinwick

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,5 +27,3 @@ The above assumes you have a .kube/config.json file that is already authenticate
 For use with ngrok, you can input `ngrok http 8077`. You can then point your github webhook at the ngrok URL.
 To rebuild the go code run `make build`. 
 You do not need to rebuild the docker image unless you make changes to the Dockerfile. You must restart your docker container after a `make build` in order to see changes
-
-

--- a/model/pull_request.go
+++ b/model/pull_request.go
@@ -16,6 +16,7 @@ type PullRequest struct {
 	FullName  string
 	Number    int
 	Username  string
+	HeadLabel string
 	Ref       string
 	Sha       string
 	Labels    []string

--- a/server/github.go
+++ b/server/github.go
@@ -229,7 +229,7 @@ func (s *Server) areChecksSuccessfulForPr(pr *model.PullRequest, org string) (bo
 	return false, nil
 }
 
-func (s *Server) PullRequestWithBranchNameExists(pr *model.PullRequest) (*model.PullRequest, error) {
+func (s *Server) pullRequestWithBranchNameExists(pr *model.PullRequest) (*model.PullRequest, error) {
 	client := newGithubClient(s.Config.GithubAccessToken)
 	prs, _, err := client.PullRequests.List(context.Background(), pr.RepoOwner, pr.RepoName, &github.PullRequestListOptions{
 		Head:  pr.HeadLabel,

--- a/server/pull_request.go
+++ b/server/pull_request.go
@@ -81,7 +81,7 @@ func (s *Server) handlePullRequestEvent(event *github.PullRequestEvent) {
 				if pr.RepoName == mattermostWebAppRepo {
 					searchSisterPR.RepoName = mattermostServerRepo
 				}
-				sisterPR, _ := s.PullRequestWithBranchNameExists(&searchSisterPR)
+				sisterPR, _ := s.pullRequestWithBranchNameExists(&searchSisterPR)
 				if sisterPR != nil {
 					// We want to update the siser PR spinwick using the current PR sha
 					sisterPR.Sha = pr.Sha


### PR DESCRIPTION
#### Summary
Trying to find a way to update mattermost-server spinwick when there's a new push on a "sister PR" in mattermost-webapp, and vice versa

#### Ticket Link
N/A OSF

#### Release Note
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

-->

```release-note
NONE
```
