### PR TITLE
Use new docker repositories

### DIFF
--- a/server/spinwick.go
+++ b/server/spinwick.go
@@ -38,8 +38,8 @@ const (
 	cwsImage             = "mattermost/cws-test"
 	cwsDeploymentName    = "cws-test"
 	cwsSecretName        = "customer-web-server-secret"
-	mattermostEEImage    = "mattermost/mm-ee-test"
-	mattermostTeamImage  = "mattermost/mm-te-test"
+	mattermostEEImage    = "mattermostdevelopment/mm-ee-test"
+	mattermostTeamImage  = "mattermostdevelopment/mm-te-test"
 	mattermostWebAppRepo = "mattermost-webapp"
 	mattermostServerRepo = "mattermost-server"
 


### PR DESCRIPTION
This configures Matterwick to use the new docker respositories where testing artifacts are pushed.

Fixes https://mattermost.atlassian.net/browse/MM-52105

```release-note
Use new docker repositories
```
