### PR TITLE
[MM-52227] - Add admin account when creating a CWS Server

### DIFF
--- a/internal/cws/client.go
+++ b/internal/cws/client.go
@@ -120,9 +120,9 @@ func (c *Client) Login(email, password string) (*User, error) {
 }
 
 // SignUp sign up a new user in the CWS service
-func (c *Client) SignUp(email, password string) (*SignupResponse, error) {
+func (c *Client) SignUp(email, password, endpoint string) (*SignupResponse, error) {
 	parameters := fmt.Sprintf(`{"email": "%s", "password": "%s"}`, email, password)
-	resp, err := c.makeRequest(c.publicURL, http.MethodPost, "/api/v1/users/signup", []byte(parameters), false)
+	resp, err := c.makeRequest(c.publicURL, http.MethodPost, endpoint, []byte(parameters), false)
 	if err != nil {
 		return nil, errors.Wrap(err, "error trying to sign up into CWS API")
 	}


### PR DESCRIPTION
#### Summary
We want to create an admin account when creating a cws spinwick server.
A dedicated endpoint that can only be called in the spinwick environment has been added to created verified admin accounts after the spinwick has been setup. This endpoint is then called by matterwick

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-52227

#### Release Note

```release-note
Create a CWS admin account when matterwick spins up new cws server
```
