### PR TITLE
Adjust mattermostServerRepo to match the rename to mattermost

### DIFF
--- a/server/spinwick.go
+++ b/server/spinwick.go
@@ -40,7 +40,7 @@ const (
 	mattermostEEImage    = "mattermostdevelopment/mm-ee-test"
 	mattermostTeamImage  = "mattermostdevelopment/mm-te-test"
 	mattermostWebAppRepo = "mattermost-webapp"
-	mattermostServerRepo = "mattermost-server"
+	mattermostServerRepo = "mattermost"
 
 	defaultMultiTenantAnnotation = "multi-tenant"
 )


### PR DESCRIPTION
#### Summary
mattermost-server was renamed to `mattermost` so this if block would never be entered. This PR adjusts the name. 
#### Ticket Link
N/A

#### Release Note
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

-->

```release-note
None
```
