### PR TITLE
[CLD-5955] CWS Spinwicks Error on Creation

### DIFF
--- a/templates/cws/cws_deployment.tmpl
+++ b/templates/cws/cws_deployment.tmpl
@@ -29,7 +29,7 @@ stringData:
   CWS_SPLIT_SERVER_ID: "{{ .Environment.CWSSplitServerID }}"
   CLOUD_DEFAULT_PRODUCT_ID: "{{ .Environment.CloudDefaultProductID }}"
   CLOUD_DEFAULT_TRIAL_PRODUCT_ID: "{{ .Environment.CloudDefaultTrialProductID }}"
-  PROVISIONER_API_KEY_AUTHENTICATION: false
+  PROVISIONER_API_KEY_AUTHENTICATION: "false"
   STRIPE_WEBHOOK_SIGNATURE_SECRET: ""
 
 ---


### PR DESCRIPTION
#### Summary
This was causing a marshaling error, as `stringData` expects all string:string but was receiving string:bool. This change corrects the error by wrapping in quotes [as it is in the manfiests](https://git.internal.mattermost.com/cloud-sre/kubernetes-workloads/gitops-self-serve/-/blob/main/apps/test/helm-values/cnc/customer-web-server-values.yaml#L146)

#### Ticket Link
https://mattermost.atlassian.net/browse/CLD-5955
#### Release Note
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

-->

```release-note
None
```
