### PR TITLE
Small fixes for CWS Stripe Webhook Registration

### DIFF
--- a/internal/cws/client.go
+++ b/internal/cws/client.go
@@ -241,7 +241,7 @@ func (c *Client) RegisterStripeWebhook(url, owner string) (string, error) {
 	}
 	defer closeBody(resp)
 	switch resp.StatusCode {
-	case http.StatusOK:
+	case http.StatusCreated:
 		body, err := ioutil.ReadAll(resp.Body)
 		if err != nil {
 			return "", errors.Wrap(err, "error trying to register stripe webhook")
@@ -254,7 +254,7 @@ func (c *Client) RegisterStripeWebhook(url, owner string) (string, error) {
 		return response.Secret, nil
 	}
 
-	return "", errors.New("Error registering Stripe Webhook")
+	return "", readAPIError(resp)
 }
 
 // DeleteStripeWebhook Calls test portal's internal API to delete a webhook endpoint in Stripe

--- a/server/spinwick.go
+++ b/server/spinwick.go
@@ -830,7 +830,7 @@ func (s *Server) destroyKubeSpinWick(pr *model.PullRequest, logger logrus.FieldL
 		OwnerID: namespaceName,
 	})
 	if err != nil {
-		logger.WithError(err).Error("Failed to get webhooks for spinwick")
+		logger.WithError(err).Error("Failed to get provisioner webhooks for spinwick")
 		request.Error = err
 		return request
 	}
@@ -838,7 +838,7 @@ func (s *Server) destroyKubeSpinWick(pr *model.PullRequest, logger logrus.FieldL
 	for _, webhook := range webhooks {
 		err = cloudClient.DeleteWebhook(webhook.ID)
 		if err != nil {
-			logger.WithError(err).Error("Failed to delete webhook")
+			logger.WithError(err).Error("Failed to delete provisioner webhook")
 			request.Error = err
 			return request
 		}


### PR DESCRIPTION
#### Summary
The webhook registration endpoint in CWS returns 201, but matterwick was expecting a 200, this caused an error. 

I've also added some better return values for the error parsing, so that it returns the problem status code rather than swallowing it. 

#### Ticket Link
https://mattermost.atlassian.net/browse/CLD-5955
#### Release Note
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

-->

```release-note
None
```
