### PR TITLE
Fix cws test servers

### DIFF
--- a/config/config-matterwick.default.json
+++ b/config/config-matterwick.default.json
@@ -56,6 +56,9 @@
       "CWSSplitKey": "",
       "CWSSplitServerID": "",
       "CloudDefaultProductID": "",
-      "CloudDefaultTrialProductID": ""
+      "CloudDefaultTrialProductID": "",
+      "CWSPublicPort": "",
+      "CWSPrivatePort": ""
+      
   }
 }

--- a/server/config.go
+++ b/server/config.go
@@ -38,6 +38,8 @@ type CWS struct {
 	CloudDefaultProductID      string
 	CloudDefaultTrialProductID string
 	DockerHubCredentials       string
+	CWSPublicPort              string
+	CWSPrivatePort             string
 }
 
 // MatterwickConfig defines all config for to run the server

--- a/server/spinwick.go
+++ b/server/spinwick.go
@@ -289,7 +289,7 @@ func (s *Server) createCWSSpinWick(pr *model.PullRequest, logger logrus.FieldLog
 	_, err = cloudClient.CreateWebhook(&cloudModel.CreateWebhookRequest{
 		// We use the namespace as the owner so it's easily fetched later
 		OwnerID: namespace.GetName(),
-		URL:     fmt.Sprintf("http://cws-test-service.%s:%s/api/v1/internal/webhook", namespace.GetName(), s.Config.CWS.CWSPublicPort),
+		URL:     fmt.Sprintf("http://cws-test-service.%s:%s/api/v1/internal/webhook", namespace.GetName(), s.Config.CWS.CWSPrivatePort),
 	})
 
 	if err != nil {

--- a/server/spinwick.go
+++ b/server/spinwick.go
@@ -338,7 +338,8 @@ func (s *Server) createCWSSpinWick(pr *model.PullRequest, logger logrus.FieldLog
 	}
 
 	spinwickURL := fmt.Sprintf("http://%s", lbURL)
-	msg := fmt.Sprintf("CWS test server created! :tada:\n\nAccess here: %s\n\nSplit individual target: %s", spinwickURL, deployment.Environment.CWSSplitServerID)
+	logLink := fmt.Sprintf("https://grafana.internal.mattermost.com/explore?orgId=1&left=%%7B%%22datasource%%22:%%22PFB2D5CACEC34D62E%%22,%%22queries%%22:%%5B%%7B%%22refId%%22:%%22A%%22,%%22expr%%22:%%22%%7Bnamespace%%3D%%5C%%22%s%%5C%%22%%7D%%22,%%22queryType%%22:%%22range%%22,%%22datasource%%22:%%7B%%22type%%22:%%22loki%%22,%%22uid%%22:%%22PFB2D5CACEC34D62E%%22%%7D,%%22editorMode%%22:%%22code%%22%%7D%%5D,%%22range%%22:%%7B%%22from%%22:%%22now-1h%%22,%%22to%%22:%%22now%%22%%7D%%7D", installation.ID)
+	msg := fmt.Sprintf("CWS test server created! :tada:\n\nAccess here: %s\n\nSplit individual target: %s\n\nLink to installation logs: [click here](%s)", spinwickURL, deployment.Environment.CWSSplitServerID, logLink)
 	s.sendGitHubComment(pr.RepoOwner, pr.RepoName, pr.Number, msg)
 
 	request.InstallationID = deployment.Namespace
@@ -497,7 +498,8 @@ func (s *Server) createSpinWick(pr *model.PullRequest, size string, withLicense 
 		return request.WithError(errors.Wrap(err, "failed to initialize the Installation")).ShouldReportError()
 	}
 	userTable := "| Account Type | Username | Password |\n|---|---|---|\n| Admin | sysadmin | Sys@dmin123 |\n| User | user-1 | User-1@123 |"
-	msg := fmt.Sprintf("Mattermost test server created! :tada:\n\nAccess here: %s\n\n%s", spinwickURL, userTable)
+	logLink := fmt.Sprintf("https://grafana.internal.mattermost.com/explore?orgId=1&left=%%7B%%22datasource%%22:%%22PFB2D5CACEC34D62E%%22,%%22queries%%22:%%5B%%7B%%22refId%%22:%%22A%%22,%%22expr%%22:%%22%%7Bnamespace%%3D%%5C%%22%s%%5C%%22%%7D%%22,%%22queryType%%22:%%22range%%22,%%22datasource%%22:%%7B%%22type%%22:%%22loki%%22,%%22uid%%22:%%22PFB2D5CACEC34D62E%%22%%7D,%%22editorMode%%22:%%22code%%22%%7D%%5D,%%22range%%22:%%7B%%22from%%22:%%22now-1h%%22,%%22to%%22:%%22now%%22%%7D%%7D", installation.ID)
+	msg := fmt.Sprintf("Mattermost test server created! :tada:\n\nAccess here: %s\n\n%s\n\nYour Spinwick's installation ID is: `%s`\nTo access the logs, please click [here](%s)", spinwickURL, userTable, installation.ID, logLink)
 	s.sendGitHubComment(pr.RepoOwner, pr.RepoName, pr.Number, msg)
 
 	return request

--- a/server/spinwick.go
+++ b/server/spinwick.go
@@ -338,8 +338,7 @@ func (s *Server) createCWSSpinWick(pr *model.PullRequest, logger logrus.FieldLog
 	}
 
 	spinwickURL := fmt.Sprintf("http://%s", lbURL)
-	logLink := fmt.Sprintf("https://grafana.internal.mattermost.com/explore?orgId=1&left=%%7B%%22datasource%%22:%%22PFB2D5CACEC34D62E%%22,%%22queries%%22:%%5B%%7B%%22refId%%22:%%22A%%22,%%22expr%%22:%%22%%7Bnamespace%%3D%%5C%%22%s%%5C%%22%%7D%%22,%%22queryType%%22:%%22range%%22,%%22datasource%%22:%%7B%%22type%%22:%%22loki%%22,%%22uid%%22:%%22PFB2D5CACEC34D62E%%22%%7D,%%22editorMode%%22:%%22code%%22%%7D%%5D,%%22range%%22:%%7B%%22from%%22:%%22now-1h%%22,%%22to%%22:%%22now%%22%%7D%%7D", installation.ID)
-	msg := fmt.Sprintf("CWS test server created! :tada:\n\nAccess here: %s\n\nSplit individual target: %s\n\nLink to installation logs: [click here](%s)", spinwickURL, deployment.Environment.CWSSplitServerID, logLink)
+	msg := fmt.Sprintf("CWS test server created! :tada:\n\nAccess here: %s\n\nSplit individual target: %s", spinwickURL, deployment.Environment.CWSSplitServerID)
 	s.sendGitHubComment(pr.RepoOwner, pr.RepoName, pr.Number, msg)
 
 	request.InstallationID = deployment.Namespace

--- a/server/spinwick.go
+++ b/server/spinwick.go
@@ -289,7 +289,7 @@ func (s *Server) createCWSSpinWick(pr *model.PullRequest, logger logrus.FieldLog
 	_, err = cloudClient.CreateWebhook(&cloudModel.CreateWebhookRequest{
 		// We use the namespace as the owner so it's easily fetched later
 		OwnerID: namespace.GetName(),
-		URL:     fmt.Sprintf("http://cws-test-service.%s:8077/api/v1/internal/webhook", namespace.GetName()),
+		URL:     fmt.Sprintf("http://cws-test-service.%s:%s/api/v1/internal/webhook", namespace.GetName(), s.Config.CWS.CWSPublicPort),
 	})
 
 	if err != nil {

--- a/server/spinwick.go
+++ b/server/spinwick.go
@@ -196,7 +196,8 @@ func (s *Server) createCloudSpinWickWithCWS(pr *model.PullRequest, size string, 
 	}
 
 	userTable := fmt.Sprintf("| Account Type | Username | Password |\n|---|---|---|\n| Admin | %s | %s |", username, password)
-	msg := fmt.Sprintf("Mattermost test server with CWS created! :tada:\n\nAccess here: %s\n\n%s", spinwickURL, userTable)
+	logLink := fmt.Sprintf("https://grafana.internal.mattermost.com/explore?orgId=1&left=%%7B%%22datasource%%22:%%22PFB2D5CACEC34D62E%%22,%%22queries%%22:%%5B%%7B%%22refId%%22:%%22A%%22,%%22expr%%22:%%22%%7Bnamespace%%3D%%5C%%22%s%%5C%%22%%7D%%22,%%22queryType%%22:%%22range%%22,%%22datasource%%22:%%7B%%22type%%22:%%22loki%%22,%%22uid%%22:%%22PFB2D5CACEC34D62E%%22%%7D,%%22editorMode%%22:%%22code%%22%%7D%%5D,%%22range%%22:%%7B%%22from%%22:%%22now-1h%%22,%%22to%%22:%%22now%%22%%7D%%7D", installation.ID)
+	msg := fmt.Sprintf("Mattermost test server with CWS created! :tada:\n\nAccess here: %s\n\n%s\n\nYour spinwick's installation ID is `%s`\nLogs can be found [here](%s)", spinwickURL, userTable, installation.ID, logLink)
 	s.sendGitHubComment(pr.RepoOwner, pr.RepoName, pr.Number, msg)
 	return request
 }

--- a/templates/cws/cws_deployment.tmpl
+++ b/templates/cws/cws_deployment.tmpl
@@ -79,10 +79,10 @@ spec:
         imagePullPolicy: IfNotPresent
         name: cws-main
         ports:
-        - containerPort: 8076
+        - containerPort: {{ .Environment.CWSPublicPort }}
           name: api
           protocol: TCP
-        - containerPort: 8077
+        - containerPort: {{ .Environment.CWSPrivatePort }}
           name: internal
           protocol: TCP
         resources: {}


### PR DESCRIPTION
#### Summary
Since the CWS server's port was changed, spinwicks were no longer able to be accessed, as it was trying to access 8076 while the container was running 8078. This makes it configurable. 
#### Ticket Link
https://mattermost.atlassian.net/browse/CLD-6520

#### Release Note
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

-->

```release-note
None
```
