### PR TITLE
Missed the LB when setting the configurable port

### DIFF
--- a/templates/cws/cws_deployment.tmpl
+++ b/templates/cws/cws_deployment.tmpl
@@ -197,8 +197,8 @@ spec:
     - name: http
       protocol: TCP
       port: 80
-      targetPort: 8076
+      targetPort: {{ .Environment.CWSPublicPort }}
     - name: https
       protocol: TCP
       port: 443
-      targetPort: 8076
+      targetPort: {{ .Environment.CWSPublicPort }}


### PR DESCRIPTION
#### Summary
Sets the LB to point at the configurable CWS ports, as currently they are hard coded to 8076 and 8077.

#### Ticket Link
<!--
If this pull request addresses a Help Wanted ticket, please link the relevant GitHub issue, e.g.

  Fixes https://github.com/mattermost/mattermost-server/issues/XXXXX

Otherwise, link the JIRA ticket.
-->

#### Release Note
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

-->

```release-note
None
```
