### PR TITLE
Append a short random ID to Spinwick Installation IDs 

### DIFF
--- a/server/spinwick.go
+++ b/server/spinwick.go
@@ -1123,7 +1123,7 @@ func checkMMPing(ctx context.Context, client *mattermostModel.Client4) error {
 
 func (s *Server) makeSpinWickID(repoName string, prNumber int) string {
 	domainName := s.Config.DNSNameTestServer
-	spinWickID := strings.ToLower(fmt.Sprintf("%s-pr-%d", repoName, prNumber))
+	spinWickID := strings.ToLower(fmt.Sprintf("%s-pr-%d-%s", repoName, prNumber, cloudModel.NewID()[0:5]))
 	// DNS names in MM cloud have a character limit. The number of characters in the domain - 64 will be how many we need to trim
 	numCharactersToTrim := len(spinWickID+domainName) - 64
 	if numCharactersToTrim > 0 {

--- a/server/spinwick.go
+++ b/server/spinwick.go
@@ -1123,12 +1123,18 @@ func checkMMPing(ctx context.Context, client *mattermostModel.Client4) error {
 
 func (s *Server) makeSpinWickID(repoName string, prNumber int) string {
 	domainName := s.Config.DNSNameTestServer
-	spinWickID := strings.ToLower(fmt.Sprintf("%s-pr-%d-%s", repoName, prNumber, cloudModel.NewID()[0:5]))
+	randomID := cloudModel.NewID()[0:5]
+	spinWickID := strings.ToLower(fmt.Sprintf("%s-pr-%d-%s", repoName, prNumber, randomID))
 	// DNS names in MM cloud have a character limit. The number of characters in the domain - 64 will be how many we need to trim
 	numCharactersToTrim := len(spinWickID+domainName) - 64
 	if numCharactersToTrim > 0 {
-		// trim the last numCharactersToTrim characters off of the repoName and overwrite spinWickID
-		spinWickID = strings.ToLower(fmt.Sprintf("%s-pr-%d", repoName[:(len(repoName)-numCharactersToTrim)], prNumber))
+		// Calculate the maximum length for repoName
+		maxRepoNameLength := len(repoName) - numCharactersToTrim
+		if maxRepoNameLength < 0 {
+			maxRepoNameLength = 0
+		}
+		// trim the repoName and reconstruct spinWickID
+		spinWickID = strings.ToLower(fmt.Sprintf("%s-pr-%d-%s", repoName[:maxRepoNameLength], prNumber, randomID))
 	}
 	return spinWickID
 }

--- a/server/spinwick_test.go
+++ b/server/spinwick_test.go
@@ -35,7 +35,6 @@ func TestMakeSpinWickID(t *testing.T) {
 		})
 	}
 }
-
 func TestMakeSpinWickIDWithLongRepositoryName(t *testing.T) {
 	spinwickLabel := "spinwick"
 	spinwickHALabel := "spinwick ha"
@@ -51,8 +50,8 @@ func TestMakeSpinWickIDWithLongRepositoryName(t *testing.T) {
 		prNumber int
 		result   string
 	}{
-		{"mattermost-server-webapp-fusion-reactor-test-really-long", 8888, "mattermost-server-webapp-fusion-re"},
-		{"mattermostserverwebappfusionreactortestreallylong", 88, "mattermostserverwebappfusionreactort"},
+		{"mattermost-server-webapp-fusion-reactor-test-really-long", 8888, "mattermost-server-webapp-fus-pr-8888-"},
+		{"mattermostserverwebappfusionreactortestreallylong", 88, "mattermostserverwebappfusionre-pr-88-"},
 	}
 
 	for _, tc := range tests {
@@ -60,7 +59,7 @@ func TestMakeSpinWickIDWithLongRepositoryName(t *testing.T) {
 			id := s.makeSpinWickID(tc.repoName, tc.prNumber)
 			assert.Contains(t, id, tc.result)
 			assert.Contains(t, id, fmt.Sprintf("%d", tc.prNumber))
-			assert.Equal(t, id, fmt.Sprintf("%s-pr-%d", tc.result, tc.prNumber))
+			assert.Len(t, id, 64-len(s.Config.DNSNameTestServer))
 		})
 	}
 }


### PR DESCRIPTION
#### Summary
Appends a short unique string to the end of an installation ID (which is used in spinwick DNS) that will stop potential DNS conflicts when rapidly deleting and recreating a spinwick for a given PR. 

#### Ticket Link
https://mattermost.atlassian.net/browse/CLD-8628

#### Release Note
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

-->

```release-note
None
```
