### PR TITLE
Add Spinwick type, concept of repeatable vs unique IDs

### DIFF
--- a/internal/cloudtools/installation.go
+++ b/internal/cloudtools/installation.go
@@ -35,7 +35,7 @@ func GetInstallationIDFromOwnerID(client *cloud.Client, serverURL, ownerID strin
 		}
 	}
 
-	return nil, errors.Errorf("found %d installations with ownerID %s", len(installations), ownerID)
+	return nil, nil
 }
 
 // GetInstallationDNSFromDNSRecords returns the active DNS record of an installation from its list of DNS records.

--- a/internal/cloudtools/installation.go
+++ b/internal/cloudtools/installation.go
@@ -5,6 +5,10 @@ import (
 	"github.com/pkg/errors"
 )
 
+func isNotDeletedState(state string) bool {
+	return state != cloud.InstallationStateDeleted && state != cloud.InstallationStateDeletionPending && state != cloud.InstallationStateDeletionRequested && state != cloud.InstallationStateDeletionFailed
+}
+
 // GetInstallationIDFromOwnerID returns the installation that matches a given
 // OwnerID. Multiple matches will return an error. No match will return
 // an empty ID and no error.
@@ -24,6 +28,14 @@ func GetInstallationIDFromOwnerID(client *cloud.Client, serverURL, ownerID strin
 	}
 	if len(installations) == 1 {
 		return installations[0], nil
+	}
+
+	// If there are more than 1 installations, return the first one that isn't deleted
+	// This allows support for creating new installations while old ones are sitting in deletion pending.
+	for _, installation := range installations {
+		if isNotDeletedState(installation.State) {
+			return installation, nil
+		}
 	}
 
 	return nil, errors.Errorf("found %d installations with ownerID %s", len(installations), ownerID)

--- a/internal/cloudtools/installation.go
+++ b/internal/cloudtools/installation.go
@@ -38,6 +38,7 @@ func GetInstallationIDFromOwnerID(client *cloud.Client, serverURL, ownerID strin
 	return nil, errors.Errorf("found %d installations with ownerID %s", len(installations), ownerID)
 }
 
+// GetInstallationDNSFromDNSRecords returns the active DNS record of an installation from its list of DNS records.
 func GetInstallationDNSFromDNSRecords(installation *cloud.InstallationDTO) string {
 	for _, dns := range installation.DNSRecords {
 		if dns != nil && dns.DeleteAt == 0 {

--- a/internal/cloudtools/installation.go
+++ b/internal/cloudtools/installation.go
@@ -40,3 +40,12 @@ func GetInstallationIDFromOwnerID(client *cloud.Client, serverURL, ownerID strin
 
 	return nil, errors.Errorf("found %d installations with ownerID %s", len(installations), ownerID)
 }
+
+func GetInstallationDNSFromDNSRecords(installation *cloud.InstallationDTO) string {
+	for _, dns := range installation.DNSRecords {
+		if dns != nil && dns.DeleteAt == 0 {
+			return dns.DomainName
+		}
+	}
+	return ""
+}

--- a/internal/cloudtools/installation.go
+++ b/internal/cloudtools/installation.go
@@ -26,9 +26,6 @@ func GetInstallationIDFromOwnerID(client *cloud.Client, serverURL, ownerID strin
 	if len(installations) == 0 {
 		return nil, nil
 	}
-	if len(installations) == 1 {
-		return installations[0], nil
-	}
 
 	// If there are more than 1 installations, return the first one that isn't deleted
 	// This allows support for creating new installations while old ones are sitting in deletion pending.

--- a/model/spinwick.go
+++ b/model/spinwick.go
@@ -7,6 +7,7 @@ import (
 	cloudModel "github.com/mattermost/mattermost-cloud/model"
 )
 
+// Spinwick is a struct that holds identifiable information about a Spinwick instance
 type Spinwick struct {
 	RepoName     string `json:"repo_name"`
 	PRNumber     int    `json:"pr_number"`
@@ -50,12 +51,12 @@ func (s *Spinwick) repeatableID() string {
 	return strings.ToLower(fmt.Sprintf("%s-pr-%d", s.RepoName, s.PRNumber))
 }
 
-// Generates a DNS name based on the unique ID and a base domain
+// DNS Generates a DNS name based on the unique ID and a base domain
 func (s *Spinwick) DNS(baseDomain string) string {
 	return fmt.Sprintf("%s.%s", s.UniqueID, baseDomain)
 }
 
-// Generates a URL based on the DNS name
+// URL Generates a URL based on the DNS name
 func (s *Spinwick) URL(baseDomain string) string {
 	return fmt.Sprintf("https://%s", s.DNS(baseDomain))
 }

--- a/model/spinwick.go
+++ b/model/spinwick.go
@@ -1,0 +1,58 @@
+package model
+
+import (
+	"fmt"
+	"strings"
+
+	cloudModel "github.com/mattermost/mattermost-cloud/model"
+)
+
+type Spinwick struct {
+	RepoName     string `json:"repo_name"`
+	PRNumber     int    `json:"pr_number"`
+	RepeatableID string `json:"repeatable_id"`
+	UniqueID     string `json:"unique_id"`
+}
+
+func NewSpinwick(repoName string, prNumber int, baseDomain string) *Spinwick {
+	spinwick := &Spinwick{
+		RepoName: repoName,
+		PRNumber: prNumber,
+	}
+
+	spinwick.RepeatableID = spinwick.repeatableID()
+	spinwick.UniqueID = spinwick.uniqueID(baseDomain)
+
+	return spinwick
+}
+
+// Generates an ID based on the PR number and repo name that's repeatable so it can be used for identifying and looking up installations
+func (s *Spinwick) uniqueID(baseDomain string) string {
+	randomID := cloudModel.NewID()[0:5]
+	spinWickID := strings.ToLower(fmt.Sprintf("%s-pr-%d-%s", s.RepoName, s.PRNumber, randomID))
+	// DNS names in MM cloud have a character limit. The number of characters in the domain - 64 will be how many we need to trim
+	numCharactersToTrim := len(spinWickID+baseDomain) - 64
+	if numCharactersToTrim > 0 {
+		// Calculate the maximum length for repoName
+		maxUniqueIDLength := len(spinWickID) - numCharactersToTrim
+		if maxUniqueIDLength < 0 {
+			maxUniqueIDLength = 0
+		}
+		// trim the repoName and reconstruct spinWickID
+		spinWickID = strings.ToLower(spinWickID[:maxUniqueIDLength])
+	}
+	return spinWickID
+}
+
+// Generates an ID based on the PR number and repo name, and appends a random string to make it unique
+func (s *Spinwick) repeatableID() string {
+	return strings.ToLower(fmt.Sprintf("%s-pr-%d", s.RepoName, s.PRNumber))
+}
+
+func (s *Spinwick) DNS(baseDomain string) string {
+	return fmt.Sprintf("%s.%s", s.UniqueID, baseDomain)
+}
+
+func (s *Spinwick) URL(baseDomain string) string {
+	return fmt.Sprintf("https://%s", s.DNS(baseDomain))
+}

--- a/model/spinwick.go
+++ b/model/spinwick.go
@@ -14,6 +14,7 @@ type Spinwick struct {
 	UniqueID     string `json:"unique_id"`
 }
 
+// NewSpinwick creates a new Spinwick instance, automatically calling the repeatableID and uniqueID methods
 func NewSpinwick(repoName string, prNumber int, baseDomain string) *Spinwick {
 	spinwick := &Spinwick{
 		RepoName: repoName,
@@ -49,10 +50,12 @@ func (s *Spinwick) repeatableID() string {
 	return strings.ToLower(fmt.Sprintf("%s-pr-%d", s.RepoName, s.PRNumber))
 }
 
+// Generates a DNS name based on the unique ID and a base domain
 func (s *Spinwick) DNS(baseDomain string) string {
 	return fmt.Sprintf("%s.%s", s.UniqueID, baseDomain)
 }
 
+// Generates a URL based on the DNS name
 func (s *Spinwick) URL(baseDomain string) string {
 	return fmt.Sprintf("https://%s", s.DNS(baseDomain))
 }

--- a/model/spinwick_test.go
+++ b/model/spinwick_test.go
@@ -1,0 +1,76 @@
+package model
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestNewSpinwick(t *testing.T) {
+	repoName := "test-repo"
+	prNumber := 123
+	baseDomain := "example.com"
+
+	spinwick := NewSpinwick(repoName, prNumber, baseDomain)
+
+	assert.Equal(t, repoName, spinwick.RepoName)
+	assert.Equal(t, prNumber, spinwick.PRNumber)
+	assert.Equal(t, "test-repo-pr-123", spinwick.RepeatableID)
+	assert.Equal(t, 22, len(spinwick.UniqueID)) //  5 char random ID + 16 chars for the rest
+}
+
+func TestSpinwick_repeatableID(t *testing.T) {
+	spinwick := &Spinwick{
+		RepoName: "Test-Repo",
+		PRNumber: 456,
+	}
+
+	assert.Equal(t, "test-repo-pr-456", spinwick.repeatableID())
+}
+
+func TestSpinwick_uniqueID(t *testing.T) {
+	t.Run("short base domain", func(t *testing.T) {
+		spinwick := &Spinwick{
+			RepoName: "mattermost",
+			PRNumber: 789,
+		}
+		baseDomain := "example.com"
+
+		uniqueID := spinwick.uniqueID(baseDomain)
+
+		assert.Equal(t, 23, len(uniqueID)) // 5 char random ID + 16 chars for the rest
+		assert.True(t, strings.HasPrefix(uniqueID, "mattermost-pr-789-"))
+	})
+
+	t.Run("long base domain", func(t *testing.T) {
+		spinwick := &Spinwick{
+			RepoName: "mattermost",
+			PRNumber: 29790,
+		}
+		baseDomain := "test.cloud.mattermost.com"
+
+		uniqueID := spinwick.uniqueID(baseDomain)
+
+		assert.LessOrEqual(t, len(uniqueID)+len(baseDomain), 64)
+		assert.True(t, strings.HasPrefix(uniqueID, "mattermost-pr-29790-"))
+	})
+
+}
+func TestSpinwick_DNS(t *testing.T) {
+	spinwick := &Spinwick{
+		UniqueID: "test-unique-id",
+	}
+	baseDomain := "example.com"
+
+	assert.Equal(t, "test-unique-id.example.com", spinwick.DNS(baseDomain))
+}
+
+func TestSpinwick_URL(t *testing.T) {
+	spinwick := &Spinwick{
+		UniqueID: "test-unique-id",
+	}
+	baseDomain := "example.com"
+
+	assert.Equal(t, "https://test-unique-id.example.com", spinwick.URL(baseDomain))
+}

--- a/server/spinwick.go
+++ b/server/spinwick.go
@@ -121,9 +121,11 @@ func (s *Server) createCloudSpinWickWithCWS(pr *model.PullRequest, size string, 
 		Aborted:        false,
 	}
 
-	uniqueID := s.makeUniqueSpinWickID(pr.RepoName, pr.Number)
-	ownerID := s.makeRepeatableSpinwickID(pr.RepoName, pr.Number)
-	spinwickURL := fmt.Sprintf("https://%s.%s", uniqueID, s.Config.DNSNameTestServer)
+	spinwick := model.NewSpinwick(pr.RepoName, pr.Number, s.Config.DNSNameTestServer)
+
+	uniqueID := spinwick.UniqueID
+	ownerID := spinwick.RepeatableID
+	spinwickURL := spinwick.URL(s.Config.DNSNameTestServer)
 	username := fmt.Sprintf("user-%s@example.mattermost.com", ownerID)
 	password := s.Config.CWSUserPassword
 
@@ -215,7 +217,9 @@ func (s *Server) createCWSSpinWick(pr *model.PullRequest, logger logrus.FieldLog
 		return request.WithError(errors.Wrap(err, "Error occurred while getting Kube Client"))
 	}
 
-	namespaceName := s.makeRepeatableSpinwickID(pr.RepoName, pr.Number)
+	spinwick := model.NewSpinwick(pr.RepoName, pr.Number, s.Config.DNSNameTestServer)
+
+	namespaceName := spinwick.RepeatableID
 	namespace, err := getOrCreateNamespace(kc, namespaceName)
 
 	if err != nil {
@@ -357,8 +361,9 @@ func (s *Server) createSpinWick(pr *model.PullRequest, size string, withLicense 
 		return request.WithError(errors.Errorf("Repository %s is not supported", pr.RepoName))
 	}
 
-	ownerID := s.makeRepeatableSpinwickID(pr.RepoName, pr.Number)
-	spinwickID := s.makeUniqueSpinWickID(pr.RepoName, pr.Number)
+	spinwick := model.NewSpinwick(pr.RepoName, pr.Number, s.Config.DNSNameTestServer)
+
+	ownerID := spinwick.RepeatableID
 	installation, err := cloudtools.GetInstallationIDFromOwnerID(s.CloudClient, s.Config.ProvisionerServer, ownerID)
 	if err != nil {
 		return request.WithError(err).ShouldReportError()
@@ -425,7 +430,7 @@ func (s *Server) createSpinWick(pr *model.PullRequest, size string, withLicense 
 		OwnerID:     ownerID,
 		Version:     version,
 		Image:       image,
-		DNS:         fmt.Sprintf("%s.%s", spinwickID, s.Config.DNSNameTestServer),
+		DNS:         spinwick.DNS(s.Config.DNSNameTestServer),
 		Size:        size,
 		Affinity:    cloudModel.InstallationAffinityMultiTenant,
 		Database:    cloudModel.InstallationDatabaseMultiTenantRDSPostgresPGBouncer,
@@ -461,7 +466,7 @@ func (s *Server) createSpinWick(pr *model.PullRequest, size string, withLicense 
 		return request.WithError(errors.Wrap(request.Error, "error waiting for installation to become stable")).ShouldReportError()
 	}
 
-	spinwickURL := fmt.Sprintf("https://%s.%s", s.makeUniqueSpinWickID(pr.RepoName, pr.Number), s.Config.DNSNameTestServer)
+	spinwickURL := fmt.Sprintf("https://%s", cloudtools.GetInstallationDNSFromDNSRecords(installation))
 	err = s.initializeMattermostTestServer(spinwickURL, pr.Number, logger)
 	if err != nil {
 		return request.WithError(errors.Wrap(err, "failed to initialize the Installation")).ShouldReportError()
@@ -521,7 +526,10 @@ func (s *Server) updateKubeSpinWick(pr *model.PullRequest, logger logrus.FieldLo
 	if err != nil {
 		return request.WithError(errors.Wrap(err, "Error occurred while getting Kube Client"))
 	}
-	namespaceName := s.makeRepeatableSpinwickID(pr.RepoName, pr.Number)
+
+	spinwick := model.NewSpinwick(pr.RepoName, pr.Number, s.Config.DNSNameTestServer)
+
+	namespaceName := spinwick.RepeatableID
 	namespaceExists, err := namespaceExists(kc, namespaceName)
 
 	if err != nil {
@@ -613,15 +621,17 @@ func (s *Server) updateSpinWick(pr *model.PullRequest, withLicense, withCloudInf
 		Aborted:        false,
 	}
 
+	spinwick := model.NewSpinwick(pr.RepoName, pr.Number, s.Config.DNSNameTestServer)
+
 	var ownerID string
 	var err error
 	if withCloudInfra {
-		ownerID, err = s.getCustomerIDFromCWS(pr.RepoName, pr.Number)
+		ownerID, err = s.getCustomerIDFromCWS(spinwick)
 		if err != nil {
 			return request.WithError(errors.Wrap(err, "error getting the owner id from CWS")).ShouldReportError()
 		}
 	} else {
-		ownerID = s.makeRepeatableSpinwickID(pr.RepoName, pr.Number)
+		ownerID = spinwick.RepeatableID
 	}
 
 	installation, err := cloudtools.GetInstallationIDFromOwnerID(s.CloudClient, s.Config.ProvisionerServer, ownerID)
@@ -689,7 +699,7 @@ func (s *Server) updateSpinWick(pr *model.PullRequest, withLicense, withCloudInf
 
 	logger.Info("Provisioning Server - Upgrade request")
 
-	_, err = cloudClient.UpdateInstallation(request.InstallationID, upgradeRequest)
+	updatedInstallation, err := cloudClient.UpdateInstallation(request.InstallationID, upgradeRequest)
 	if err != nil {
 		return request.WithError(errors.Wrap(err, "unable to make upgrade request to provisioning server")).ShouldReportError()
 	}
@@ -712,7 +722,7 @@ func (s *Server) updateSpinWick(pr *model.PullRequest, withLicense, withCloudInf
 		s.removeCommentsWithSpecificMessages(comments, serverUpdateMessage, pr, logger)
 	}
 
-	mmURL := fmt.Sprintf("https://%s.%s", s.makeRepeatableSpinwickID(pr.RepoName, pr.Number), s.Config.DNSNameTestServer)
+	mmURL := fmt.Sprintf("https://%s", cloudtools.GetInstallationDNSFromDNSRecords(updatedInstallation))
 	msg := fmt.Sprintf("Mattermost test server updated with git commit `%s`.\n\nAccess here: %s", pr.Sha, mmURL)
 	s.sendGitHubComment(pr.RepoOwner, pr.RepoName, pr.Number, msg)
 
@@ -763,7 +773,12 @@ func (s *Server) destroyKubeSpinWick(pr *model.PullRequest, logger logrus.FieldL
 		Aborted:        false,
 	}
 
-	namespaceName := s.makeRepeatableSpinwickID(pr.RepoName, pr.Number)
+	spinwick := &model.Spinwick{
+		RepoName: pr.RepoName,
+		PRNumber: pr.Number,
+	}
+
+	namespaceName := spinwick.RepeatableID
 
 	kc, err := s.newClient(logger)
 	if err != nil {
@@ -839,7 +854,12 @@ func (s *Server) destroyCloudSpinWickWithCWS(pr *model.PullRequest, logger logru
 		Aborted:        false,
 	}
 
-	ownerID := s.makeRepeatableSpinwickID(pr.RepoName, pr.Number)
+	spinwick := &model.Spinwick{
+		RepoName: pr.RepoName,
+		PRNumber: pr.Number,
+	}
+
+	ownerID := spinwick.RepeatableID
 	username := fmt.Sprintf("user-%s@example.mattermost.com", ownerID)
 	password := s.Config.CWSUserPassword
 
@@ -895,7 +915,12 @@ func (s *Server) destroySpinWick(pr *model.PullRequest, logger logrus.FieldLogge
 		Aborted:        false,
 	}
 
-	ownerID := s.makeRepeatableSpinwickID(pr.RepoName, pr.Number)
+	spinwick := &model.Spinwick{
+		RepoName: pr.RepoName,
+		PRNumber: pr.Number,
+	}
+
+	ownerID := spinwick.RepeatableID
 	installation, err := cloudtools.GetInstallationIDFromOwnerID(s.CloudClient, s.Config.ProvisionerServer, ownerID)
 	if err != nil {
 		return request.WithError(err).ShouldReportError()
@@ -1123,33 +1148,9 @@ func checkMMPing(ctx context.Context, client *mattermostModel.Client4) error {
 	}
 }
 
-// Generates an ID based on the PR number and repo name, and appends a random string to make it unique
-func (s *Server) makeUniqueSpinWickID(repoName string, prNumber int) string {
-	domainName := s.Config.DNSNameTestServer
-	randomID := cloudModel.NewID()[0:5]
-	spinWickID := strings.ToLower(fmt.Sprintf("%s-pr-%d-%s", repoName, prNumber, randomID))
-	// DNS names in MM cloud have a character limit. The number of characters in the domain - 64 will be how many we need to trim
-	numCharactersToTrim := len(spinWickID+domainName) - 64
-	if numCharactersToTrim > 0 {
-		// Calculate the maximum length for repoName
-		maxRepoNameLength := len(repoName) - numCharactersToTrim
-		if maxRepoNameLength < 0 {
-			maxRepoNameLength = 0
-		}
-		// trim the repoName and reconstruct spinWickID
-		spinWickID = strings.ToLower(fmt.Sprintf("%s-pr-%d-%s", repoName[:maxRepoNameLength], prNumber, randomID))
-	}
-	return spinWickID
-}
-
-// Generates an ID based on the PR number and repo name that's repeatable so it can be used for identifying and looking up installations
-func (s *Server) makeRepeatableSpinwickID(repoName string, prNumber int) string {
-	return strings.ToLower(fmt.Sprintf("%s-pr-%d", repoName, prNumber))
-}
-
-func (s *Server) getCustomerIDFromCWS(repoName string, prNumber int) (string, error) {
+func (s *Server) getCustomerIDFromCWS(spinwick *model.Spinwick) (string, error) {
 	cwsClient := cws.NewClient(s.Config.CWSPublicAPIAddress, s.Config.CWSInternalAPIAddress, s.Config.CWSAPIKey)
-	ownerID := s.makeRepeatableSpinwickID(repoName, prNumber)
+	ownerID := spinwick.RepeatableID
 	_, err := cwsClient.Login(
 		fmt.Sprintf("user-%s@example.mattermost.com", ownerID),
 		s.Config.CWSUserPassword,

--- a/server/spinwick.go
+++ b/server/spinwick.go
@@ -773,10 +773,7 @@ func (s *Server) destroyKubeSpinWick(pr *model.PullRequest, logger logrus.FieldL
 		Aborted:        false,
 	}
 
-	spinwick := &model.Spinwick{
-		RepoName: pr.RepoName,
-		PRNumber: pr.Number,
-	}
+	spinwick := model.NewSpinwick(pr.RepoName, pr.Number, s.Config.DNSNameTestServer)
 
 	namespaceName := spinwick.RepeatableID
 
@@ -854,10 +851,7 @@ func (s *Server) destroyCloudSpinWickWithCWS(pr *model.PullRequest, logger logru
 		Aborted:        false,
 	}
 
-	spinwick := &model.Spinwick{
-		RepoName: pr.RepoName,
-		PRNumber: pr.Number,
-	}
+	spinwick := model.NewSpinwick(pr.RepoName, pr.Number, s.Config.DNSNameTestServer)
 
 	ownerID := spinwick.RepeatableID
 	username := fmt.Sprintf("user-%s@example.mattermost.com", ownerID)
@@ -915,10 +909,7 @@ func (s *Server) destroySpinWick(pr *model.PullRequest, logger logrus.FieldLogge
 		Aborted:        false,
 	}
 
-	spinwick := &model.Spinwick{
-		RepoName: pr.RepoName,
-		PRNumber: pr.Number,
-	}
+	spinwick := model.NewSpinwick(pr.RepoName, pr.Number, s.Config.DNSNameTestServer)
 
 	ownerID := spinwick.RepeatableID
 	installation, err := cloudtools.GetInstallationIDFromOwnerID(s.CloudClient, s.Config.ProvisionerServer, ownerID)

--- a/server/spinwick.go
+++ b/server/spinwick.go
@@ -712,7 +712,7 @@ func (s *Server) updateSpinWick(pr *model.PullRequest, withLicense, withCloudInf
 		s.removeCommentsWithSpecificMessages(comments, serverUpdateMessage, pr, logger)
 	}
 
-	mmURL := fmt.Sprintf("https://%s.%s", s.makeUniqueSpinWickID(pr.RepoName, pr.Number), s.Config.DNSNameTestServer)
+	mmURL := fmt.Sprintf("https://%s.%s", s.makeRepeatableSpinwickID(pr.RepoName, pr.Number), s.Config.DNSNameTestServer)
 	msg := fmt.Sprintf("Mattermost test server updated with git commit `%s`.\n\nAccess here: %s", pr.Sha, mmURL)
 	s.sendGitHubComment(pr.RepoOwner, pr.RepoName, pr.Number, msg)
 
@@ -763,7 +763,7 @@ func (s *Server) destroyKubeSpinWick(pr *model.PullRequest, logger logrus.FieldL
 		Aborted:        false,
 	}
 
-	namespaceName := s.makeUniqueSpinWickID(pr.RepoName, pr.Number)
+	namespaceName := s.makeRepeatableSpinwickID(pr.RepoName, pr.Number)
 
 	kc, err := s.newClient(logger)
 	if err != nil {
@@ -839,8 +839,8 @@ func (s *Server) destroyCloudSpinWickWithCWS(pr *model.PullRequest, logger logru
 		Aborted:        false,
 	}
 
-	uniqueID := s.makeUniqueSpinWickID(pr.RepoName, pr.Number)
-	username := fmt.Sprintf("user-%s@example.mattermost.com", uniqueID)
+	ownerID := s.makeRepeatableSpinwickID(pr.RepoName, pr.Number)
+	username := fmt.Sprintf("user-%s@example.mattermost.com", ownerID)
 	password := s.Config.CWSUserPassword
 
 	cwsClient := cws.NewClient(s.Config.CWSPublicAPIAddress, s.Config.CWSInternalAPIAddress, s.Config.CWSAPIKey)
@@ -895,7 +895,7 @@ func (s *Server) destroySpinWick(pr *model.PullRequest, logger logrus.FieldLogge
 		Aborted:        false,
 	}
 
-	ownerID := s.makeUniqueSpinWickID(pr.RepoName, pr.Number)
+	ownerID := s.makeRepeatableSpinwickID(pr.RepoName, pr.Number)
 	installation, err := cloudtools.GetInstallationIDFromOwnerID(s.CloudClient, s.Config.ProvisionerServer, ownerID)
 	if err != nil {
 		return request.WithError(err).ShouldReportError()
@@ -1149,9 +1149,9 @@ func (s *Server) makeRepeatableSpinwickID(repoName string, prNumber int) string 
 
 func (s *Server) getCustomerIDFromCWS(repoName string, prNumber int) (string, error) {
 	cwsClient := cws.NewClient(s.Config.CWSPublicAPIAddress, s.Config.CWSInternalAPIAddress, s.Config.CWSAPIKey)
-	uniqueID := s.makeUniqueSpinWickID(repoName, prNumber)
+	ownerID := s.makeRepeatableSpinwickID(repoName, prNumber)
 	_, err := cwsClient.Login(
-		fmt.Sprintf("user-%s@example.mattermost.com", uniqueID),
+		fmt.Sprintf("user-%s@example.mattermost.com", ownerID),
 		s.Config.CWSUserPassword,
 	)
 	if err != nil {

--- a/server/spinwick.go
+++ b/server/spinwick.go
@@ -121,9 +121,10 @@ func (s *Server) createCloudSpinWickWithCWS(pr *model.PullRequest, size string, 
 		Aborted:        false,
 	}
 
-	uniqueID := s.makeRepeatableSpinwickID(pr.RepoName, pr.Number)
+	uniqueID := s.makeUniqueSpinWickID(pr.RepoName, pr.Number)
+	ownerID := s.makeRepeatableSpinwickID(pr.RepoName, pr.Number)
 	spinwickURL := fmt.Sprintf("https://%s.%s", uniqueID, s.Config.DNSNameTestServer)
-	username := fmt.Sprintf("user-%s@example.mattermost.com", uniqueID)
+	username := fmt.Sprintf("user-%s@example.mattermost.com", ownerID)
 	password := s.Config.CWSUserPassword
 
 	// We try to login with an existing account and get the customer ID to create the installation

--- a/server/spinwick_test.go
+++ b/server/spinwick_test.go
@@ -8,7 +8,32 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestMakeSpinWickID(t *testing.T) {
+func TestmakeRepeatableSpinwickID(t *testing.T) {
+	s := &Server{
+		Config: &MatterwickConfig{
+			DNSNameTestServer: ".test.mattermost.cloud",
+		},
+	}
+
+	tests := []struct {
+		repoName string
+		prNumber int
+	}{
+		{"mattermost-server", 12345},
+		{"mattermost-webapp", 54321},
+		{"mattermost-fusion-reactor", 777},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.repoName, func(t *testing.T) {
+			id := s.makeRepeatableSpinwickID(tc.repoName, tc.prNumber)
+			assert.Contains(t, id, tc.repoName)
+			assert.Contains(t, id, fmt.Sprintf("%d", tc.prNumber))
+		})
+	}
+}
+
+func TestmakeUniqueSpinWickID(t *testing.T) {
 	spinwickLabel := "spinwick"
 	spinwickHALabel := "spinwick ha"
 	s := &Server{
@@ -29,7 +54,7 @@ func TestMakeSpinWickID(t *testing.T) {
 
 	for _, tc := range tests {
 		t.Run(tc.repoName, func(t *testing.T) {
-			id := s.makeSpinWickID(tc.repoName, tc.prNumber)
+			id := s.makeUniqueSpinWickID(tc.repoName, tc.prNumber)
 			assert.Contains(t, id, tc.repoName)
 			assert.Contains(t, id, fmt.Sprintf("%d", tc.prNumber))
 		})
@@ -56,7 +81,7 @@ func TestMakeSpinWickIDWithLongRepositoryName(t *testing.T) {
 
 	for _, tc := range tests {
 		t.Run(tc.repoName, func(t *testing.T) {
-			id := s.makeSpinWickID(tc.repoName, tc.prNumber)
+			id := s.makeUniqueSpinWickID(tc.repoName, tc.prNumber)
 			assert.Contains(t, id, tc.result)
 			assert.Contains(t, id, fmt.Sprintf("%d", tc.prNumber))
 			assert.Len(t, id, 64-len(s.Config.DNSNameTestServer))

--- a/server/spinwick_test.go
+++ b/server/spinwick_test.go
@@ -8,7 +8,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestmakeRepeatableSpinwickID(t *testing.T) {
+func TestMakeRepeatableSpinwickID(t *testing.T) {
 	s := &Server{
 		Config: &MatterwickConfig{
 			DNSNameTestServer: ".test.mattermost.cloud",
@@ -33,7 +33,7 @@ func TestmakeRepeatableSpinwickID(t *testing.T) {
 	}
 }
 
-func TestmakeUniqueSpinWickID(t *testing.T) {
+func TestMakeUniqueSpinWickID(t *testing.T) {
 	spinwickLabel := "spinwick"
 	spinwickHALabel := "spinwick ha"
 	s := &Server{

--- a/server/spinwick_test.go
+++ b/server/spinwick_test.go
@@ -1,93 +1,10 @@
 package server
 
 import (
-	"fmt"
 	"testing"
 
-	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
-
-func TestMakeRepeatableSpinwickID(t *testing.T) {
-	s := &Server{
-		Config: &MatterwickConfig{
-			DNSNameTestServer: ".test.mattermost.cloud",
-		},
-	}
-
-	tests := []struct {
-		repoName string
-		prNumber int
-	}{
-		{"mattermost-server", 12345},
-		{"mattermost-webapp", 54321},
-		{"mattermost-fusion-reactor", 777},
-	}
-
-	for _, tc := range tests {
-		t.Run(tc.repoName, func(t *testing.T) {
-			id := s.makeRepeatableSpinwickID(tc.repoName, tc.prNumber)
-			assert.Contains(t, id, tc.repoName)
-			assert.Contains(t, id, fmt.Sprintf("%d", tc.prNumber))
-		})
-	}
-}
-
-func TestMakeUniqueSpinWickID(t *testing.T) {
-	spinwickLabel := "spinwick"
-	spinwickHALabel := "spinwick ha"
-	s := &Server{
-		Config: &MatterwickConfig{
-			SetupSpinWick:     spinwickLabel,
-			SetupSpinWickHA:   spinwickHALabel,
-			DNSNameTestServer: ".test.mattermost.cloud",
-		},
-	}
-	tests := []struct {
-		repoName string
-		prNumber int
-	}{
-		{"mattermost-server", 12345},
-		{"mattermost-webapp", 54321},
-		{"mattermost-fusion-reactor", 777},
-	}
-
-	for _, tc := range tests {
-		t.Run(tc.repoName, func(t *testing.T) {
-			id := s.makeUniqueSpinWickID(tc.repoName, tc.prNumber)
-			assert.Contains(t, id, tc.repoName)
-			assert.Contains(t, id, fmt.Sprintf("%d", tc.prNumber))
-		})
-	}
-}
-func TestMakeSpinWickIDWithLongRepositoryName(t *testing.T) {
-	spinwickLabel := "spinwick"
-	spinwickHALabel := "spinwick ha"
-	s := &Server{
-		Config: &MatterwickConfig{
-			SetupSpinWick:     spinwickLabel,
-			SetupSpinWickHA:   spinwickHALabel,
-			DNSNameTestServer: ".test.mattermost.cloud",
-		},
-	}
-	tests := []struct {
-		repoName string
-		prNumber int
-		result   string
-	}{
-		{"mattermost-server-webapp-fusion-reactor-test-really-long", 8888, "mattermost-server-webapp-fus-pr-8888-"},
-		{"mattermostserverwebappfusionreactortestreallylong", 88, "mattermostserverwebappfusionre-pr-88-"},
-	}
-
-	for _, tc := range tests {
-		t.Run(tc.repoName, func(t *testing.T) {
-			id := s.makeUniqueSpinWickID(tc.repoName, tc.prNumber)
-			assert.Contains(t, id, tc.result)
-			assert.Contains(t, id, fmt.Sprintf("%d", tc.prNumber))
-			assert.Len(t, id, 64-len(s.Config.DNSNameTestServer))
-		})
-	}
-}
 
 func TestIsSpinWickLabel(t *testing.T) {
 	spinwickLabel := "spinwick"


### PR DESCRIPTION
#### Summary
In https://github.com/mattermost/matterwick/pull/67 a new concept of unique Spinwick IDs was introduced to allow support for deletion pending windows. This worked for creation but was problematic for updates, since the same always-unique spinwick ID is assigned as the workspace OwnerID, and couldn't be looked up after creation. This PR adjusts logic so that the 2 types of spinwick IDs can be generated - repeatable, and unique. The former is used for OwnerID, and other lookups, while the latter is used for DNS names. 



#### Ticket Link
N/A
#### Release Note
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

-->

```release-note
None
```
