### PR TITLE
[MM-62271] Implement `/spinwick` slash command

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -43,3 +43,5 @@ Session.vim
 
 /.idea
 bin/
+
+.aider*

--- a/internal/cloudtools/installation.go
+++ b/internal/cloudtools/installation.go
@@ -6,7 +6,14 @@ import (
 )
 
 func isNotDeletedState(state string) bool {
-	return state != cloud.InstallationStateDeleted && state != cloud.InstallationStateDeletionPending && state != cloud.InstallationStateDeletionRequested && state != cloud.InstallationStateDeletionFailed
+	switch state {
+	case cloud.InstallationStateDeleted, cloud.InstallationStateDeletionPending,
+		cloud.InstallationStateDeletionPendingRequested, cloud.InstallationStateDeletionRequested,
+		cloud.InstallationStateDeletionPendingInProgress, cloud.InstallationStateDeletionFailed:
+		return false
+	default:
+		return true
+	}
 }
 
 // GetInstallationIDFromOwnerID returns the installation that matches a given

--- a/internal/cws/client.go
+++ b/internal/cws/client.go
@@ -6,7 +6,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"net/http"
 	"time"
 
@@ -109,7 +108,7 @@ func (c *Client) Login(email, password string) (*User, error) {
 
 	switch resp.StatusCode {
 	case http.StatusOK:
-		body, err := ioutil.ReadAll(resp.Body)
+		body, err := io.ReadAll(resp.Body)
 		if err != nil {
 			return nil, errors.Wrap(err, "error trying to log into CWS API")
 		}
@@ -135,7 +134,7 @@ func (c *Client) SignUp(email, password string) (*SignupResponse, error) {
 
 	switch resp.StatusCode {
 	case http.StatusCreated:
-		body, err := ioutil.ReadAll(resp.Body)
+		body, err := io.ReadAll(resp.Body)
 		if err != nil {
 			return nil, errors.Wrap(err, "error trying to sign up into CWS API")
 		}
@@ -161,7 +160,7 @@ func (c *Client) GetMyCustomers() ([]*Customer, error) {
 
 	switch resp.StatusCode {
 	case http.StatusOK:
-		body, err := ioutil.ReadAll(resp.Body)
+		body, err := io.ReadAll(resp.Body)
 		if err != nil {
 			return nil, errors.Wrap(err, "error trying to request my customers from CWS API")
 		}
@@ -203,7 +202,7 @@ func (c *Client) CreateInstallation(installationRequest *CreateInstallationReque
 	defer closeBody(resp)
 	switch resp.StatusCode {
 	case http.StatusOK:
-		body, err := ioutil.ReadAll(resp.Body)
+		body, err := io.ReadAll(resp.Body)
 		if err != nil {
 			return nil, errors.Wrap(err, "error trying to create CWS installation")
 		}
@@ -242,7 +241,7 @@ func (c *Client) RegisterStripeWebhook(url, owner string) (string, error) {
 	defer closeBody(resp)
 	switch resp.StatusCode {
 	case http.StatusCreated:
-		body, err := ioutil.ReadAll(resp.Body)
+		body, err := io.ReadAll(resp.Body)
 		if err != nil {
 			return "", errors.Wrap(err, "error trying to register stripe webhook")
 		}
@@ -282,7 +281,7 @@ func (c *Client) GetInstallations() ([]*Installation, error) {
 	defer closeBody(resp)
 	switch resp.StatusCode {
 	case http.StatusOK:
-		body, err := ioutil.ReadAll(resp.Body)
+		body, err := io.ReadAll(resp.Body)
 		if err != nil {
 			return nil, errors.Wrap(err, "error trying to get CWS installation")
 		}
@@ -321,7 +320,7 @@ func (c *Client) makeRequest(host, method, path string, body []byte, isInternal 
 
 func closeBody(r *http.Response) {
 	if r.Body != nil {
-		_, _ = ioutil.ReadAll(r.Body)
+		_, _ = io.ReadAll(r.Body)
 		_ = r.Body.Close()
 	}
 }

--- a/model/cloud_client.go
+++ b/model/cloud_client.go
@@ -6,5 +6,6 @@ import (
 
 // NewCloudClientWithOAuth creates a new cloud client with OAuth.
 func NewCloudClientWithOAuth(address, clientID, clientSecret, tokenEndpoint string) *cloudModel.Client {
-	return cloudModel.NewClient(address)
+	var headers map[string]string
+	return cloudModel.NewClientWithOAuth(address, headers, clientID, clientSecret, tokenEndpoint)
 }

--- a/model/cloud_client.go
+++ b/model/cloud_client.go
@@ -6,6 +6,5 @@ import (
 
 // NewCloudClientWithOAuth creates a new cloud client with OAuth.
 func NewCloudClientWithOAuth(address, clientID, clientSecret, tokenEndpoint string) *cloudModel.Client {
-	var headers map[string]string
-	return cloudModel.NewClientWithOAuth(address, headers, clientID, clientSecret, tokenEndpoint)
+	return cloudModel.NewClient(address)
 }

--- a/server/github.go
+++ b/server/github.go
@@ -6,6 +6,7 @@ package server
 import (
 	"context"
 	"encoding/json"
+	"fmt"
 	"io"
 
 	"github.com/mattermost/matterwick/model"
@@ -86,6 +87,23 @@ func (s *Server) GetPullRequestFromGithub(pullRequest *github.PullRequest) (*mod
 	return pr, nil
 }
 
+func (s *Server) getPullRequestFromIssue(issue *github.Issue, repo *github.Repository) (*github.PullRequest, error) {
+	if !issue.IsPullRequest() {
+		return nil, fmt.Errorf("issue is not a pull request")
+	}
+
+	client := newGithubClient(s.Config.GithubAccessToken)
+
+	// Fetch the pull request
+	pr, _, err := client.PullRequests.Get(context.Background(),
+		repo.GetOwner().GetLogin(), repo.GetName(), issue.GetNumber())
+	if err != nil {
+		return nil, fmt.Errorf("failed to get pull request: %w", err)
+	}
+
+	return pr, nil
+}
+
 func labelsToStringArray(labels []*github.Label) []string {
 	out := make([]string, len(labels))
 
@@ -116,6 +134,16 @@ func (s *Server) removeLabel(repoOwner, repoName string, number int, label strin
 	}
 }
 
+func (s *Server) addLabel(repoOwner, repoName string, number int, label string) {
+	logger := s.Logger.WithFields(logrus.Fields{"issue": number, "label": label})
+	logger.Info("Adding label on issue")
+	client := newGithubClient(s.Config.GithubAccessToken)
+	_, _, err := client.Issues.AddLabelsToIssue(context.Background(), repoOwner, repoName, number, []string{label})
+	if err != nil {
+		logger.WithError(err).Error("Error adding the label")
+	}
+}
+
 func (s *Server) getComments(repoOwner, repoName string, number int) ([]*github.IssueComment, error) {
 	client := newGithubClient(s.Config.GithubAccessToken)
 	comments, _, err := client.Issues.ListComments(context.Background(), repoOwner, repoName, number, nil)
@@ -142,10 +170,11 @@ func (s *Server) checkUserPermission(user, repoOwner string) bool {
 
 	_, resp, err := client.Organizations.GetOrgMembership(context.Background(), user, repoOwner)
 	if resp.StatusCode == 404 {
-		s.Logger.Warnf("User %s is not part of the ORG", user)
+		s.Logger.Warnf("User %s is not part of the ORG %s", user, repoOwner)
 		return false
 	}
 	if err != nil {
+		s.Logger.WithError(err).Error("failed to get org membership")
 		return false
 	}
 
@@ -185,7 +214,6 @@ func (s *Server) createRef(pr *model.PullRequest, ref string) {
 				SHA: github.String(pr.Sha),
 			},
 		})
-
 	if err != nil {
 		s.Logger.WithError(err).Error("Failed to create reference")
 	}

--- a/server/pull_request.go
+++ b/server/pull_request.go
@@ -27,6 +27,8 @@ func (s *Server) handlePullRequestEvent(event *github.PullRequestEvent) {
 		return
 	}
 
+	spinwick := model.NewSpinwick(pr.RepoName, pr.Number, s.Config.DNSNameTestServer)
+
 	switch event.GetAction() {
 	case "opened":
 		logger.Info("PR opened")
@@ -37,15 +39,16 @@ func (s *Server) handlePullRequestEvent(event *github.PullRequestEvent) {
 			logger.Error("Label event received, but label object was empty")
 			return
 		}
+
 		if s.isSpinWickLabel(label) {
 			logger.WithField("label", label).Info("PR received SpinWick label")
 			switch *event.Label.Name {
 			case s.Config.SetupSpinWick:
-				s.handleCreateSpinWick(pr, "miniSingleton", false, false)
+				s.handleCreateSpinWick(pr, "miniSingleton", false, false, s.getEnvMap(spinwick.RepeatableID))
 			case s.Config.SetupSpinWickHA:
-				s.handleCreateSpinWick(pr, "miniHA", true, false)
+				s.handleCreateSpinWick(pr, "miniHA", true, false, s.getEnvMap(spinwick.RepeatableID))
 			case s.Config.SetupSpinWickWithCWS:
-				s.handleCreateSpinWick(pr, "miniSingleton", true, true)
+				s.handleCreateSpinWick(pr, "miniSingleton", true, true, s.getEnvMap(spinwick.RepeatableID))
 			default:
 				logger.WithField("label", label).Error("Failed to determine sizing on SpinWick label")
 			}
@@ -66,15 +69,8 @@ func (s *Server) handlePullRequestEvent(event *github.PullRequestEvent) {
 		}
 	case "synchronize":
 		logger.Info("PR has a new commit")
-		if s.isSpinWickLabelInLabels(pr.Labels) {
-			if s.isSpinWickHALabel(pr.Labels) {
-				s.handleUpdateSpinWick(pr, true, false)
-			} else if s.isSpinWickCloudWithCWSLabel(pr.Labels) {
-				s.handleUpdateSpinWick(pr, true, true)
-			} else {
-				s.handleUpdateSpinWick(pr, false, false)
-			}
-		}
+
+		s.handleSynchronizeSpinwick(pr, spinwick.RepeatableID, false)
 	case "closed":
 		logger.Info("PR was closed")
 		if s.isSpinWickLabelInLabels(pr.Labels) {
@@ -85,7 +81,18 @@ func (s *Server) handlePullRequestEvent(event *github.PullRequestEvent) {
 			}
 		}
 	}
+}
 
+func (s *Server) handleSynchronizeSpinwick(pr *model.PullRequest, spinwickID string, noBuildChanges bool) {
+	if s.isSpinWickLabelInLabels(pr.Labels) {
+		if s.isSpinWickHALabel(pr.Labels) {
+			s.handleUpdateSpinWick(pr, true, false, noBuildChanges, s.getEnvMap(spinwickID))
+		} else if s.isSpinWickCloudWithCWSLabel(pr.Labels) {
+			s.handleUpdateSpinWick(pr, true, true, noBuildChanges, s.getEnvMap(spinwickID))
+		} else {
+			s.handleUpdateSpinWick(pr, false, false, noBuildChanges, s.getEnvMap(spinwickID))
+		}
+	}
 }
 
 func (s *Server) removeOldComments(comments []*github.IssueComment, pr *model.PullRequest, logger logrus.FieldLogger) {

--- a/server/server.go
+++ b/server/server.go
@@ -59,7 +59,12 @@ func New(config *MatterwickConfig) *Server {
 		logger.SetFormatter(&logrus.JSONFormatter{})
 	}
 
-	cloudClient := model.NewCloudClientWithOAuth(config.ProvisionerServer, config.CloudAuth.ClientID, config.CloudAuth.ClientSecret, config.CloudAuth.TokenEndpoint)
+	var cloudClient *cloudModel.Client
+	if os.Getenv("MATTERWICK_LOCAL_TESTING") == "true" {
+		cloudClient = cloudModel.NewClient(config.ProvisionerServer)
+	} else {
+		cloudClient = model.NewCloudClientWithOAuth(config.ProvisionerServer, config.CloudAuth.ClientID, config.CloudAuth.ClientSecret, config.CloudAuth.TokenEndpoint)
+	}
 
 	s := &Server{
 		Config:          config,

--- a/server/slash_commands.go
+++ b/server/slash_commands.go
@@ -125,7 +125,7 @@ func (s *Server) parseSpinwickSlashCommandArgs(args []string, isUpdate bool) (sp
 	if isUpdate {
 		flagset.StringVar(&clearEnv, "clear-env", "", "An optional comma-separated list of environment variables to clear. Example: VAR1,VAR2")
 	} else {
-		flagset.StringVar(&size, "size", "miniHA", "Size of the Mattermost installation e.g. 'miniSingleton' or 'miniHA'")
+		flagset.StringVar(&size, "size", "miniSingleton", "Size of the Mattermost installation e.g. 'miniSingleton' or 'miniHA'")
 	}
 
 	err := flagset.Parse(args)

--- a/server/slash_commands.go
+++ b/server/slash_commands.go
@@ -1,0 +1,226 @@
+package server
+
+import (
+	"bytes"
+	"errors"
+	"flag"
+	"fmt"
+	"os"
+	"strings"
+
+	"github.com/google/go-github/v32/github"
+	cloudModel "github.com/mattermost/mattermost-cloud/model"
+	"github.com/mattermost/matterwick/model"
+	"github.com/sirupsen/logrus"
+)
+
+const (
+	slashCommandSpinWick  = "/spinwick"
+	slashCommandShrugWick = "/shrugwick"
+)
+
+type (
+	spinWickCreateHandlerFn       func(envMap cloudModel.EnvVarMap, size string)
+	spinWickUpdateHandlerFn       func(envMap cloudModel.EnvVarMap)
+	spinWickDeleteHandlerFn       func()
+	spinWickSlashCommandsHandlers struct {
+		createHandler spinWickCreateHandlerFn
+		updateHandler spinWickUpdateHandlerFn
+		deleteHandler spinWickDeleteHandlerFn
+	}
+	spinWickSlashCommandArgs struct {
+		envMap cloudModel.EnvVarMap
+		size   string
+	}
+)
+
+func (s *Server) handleSlashCommand(cmd string, ev *github.IssueCommentEvent) {
+	s.Logger.WithField("cmd", cmd).Info("handling slash command")
+
+	if os.Getenv("MATTERWICK_LOCAL_TESTING") != "true" {
+		// Ensure user sending the command has permissions to do so.
+		if ok := s.checkUserPermission(ev.GetSender().GetLogin(), ev.GetRepo().GetOwner().GetLogin()); !ok {
+			s.Logger.Error("no permission")
+			return
+		}
+	}
+
+	args := strings.Fields(cmd)
+	if len(args) == 0 {
+		s.Logger.WithField("cmd", cmd).Error("no args")
+		return
+	}
+
+	githubPR, err := s.getPullRequestFromIssue(ev.GetIssue(), ev.GetRepo())
+	if err != nil {
+		logger.WithError(err).Error("failed to get GitHub PR")
+		return
+	}
+
+	pr, err := s.GetPullRequestFromGithub(githubPR)
+	if err != nil {
+		logger.WithError(err).Error("failed to get PR")
+		return
+	}
+
+	spinWickHandlers := spinWickSlashCommandsHandlers{
+		createHandler: func(envMap cloudModel.EnvVarMap, size string) {
+			spinwick := model.NewSpinwick(pr.RepoName, pr.Number, s.Config.DNSNameTestServer)
+			s.envMapsLock.Lock()
+			s.envMaps[spinwick.RepeatableID] = envMap
+			s.envMapsLock.Unlock()
+
+			label := s.Config.SetupSpinWick
+			if size == "miniHA" {
+				label = s.Config.SetupSpinWickHA
+			}
+			s.addLabel(pr.RepoOwner, pr.RepoName, pr.Number, label)
+		},
+		updateHandler: func(envMap cloudModel.EnvVarMap) {
+			spinwick := model.NewSpinwick(pr.RepoName, pr.Number, s.Config.DNSNameTestServer)
+			s.envMapsLock.Lock()
+			s.envMaps[spinwick.RepeatableID] = envMap
+			s.envMapsLock.Unlock()
+
+			s.handleSynchronizeSpinwick(pr, spinwick.RepeatableID, true)
+		},
+		deleteHandler: func() {
+			for _, label := range pr.Labels {
+				if s.isSpinWickLabel(label) {
+					s.removeLabel(pr.RepoOwner, pr.RepoName, pr.Number, label)
+				}
+			}
+		},
+	}
+
+	switch args[0] {
+	case slashCommandSpinWick:
+		output, err := s.handleSpinWickSlashCommand(args[1:], spinWickHandlers)
+		if err != nil {
+			s.Logger.WithError(err).Error("failed to handle spinwick command")
+		}
+		if output != "" {
+			s.sendGitHubComment(ev.GetRepo().GetOwner().GetLogin(),
+				ev.GetRepo().GetName(),
+				ev.GetIssue().GetNumber(), fmt.Sprintf("```\n%s\n```", output))
+		}
+	case slashCommandShrugWick:
+		s.handleShrugWick(ev)
+	default:
+		s.Logger.WithField("cmd", cmd).Error("invalid slash command")
+	}
+}
+
+func (s *Server) parseSpinwickSlashCommandArgs(args []string, isUpdate bool) (spinWickSlashCommandArgs, string, error) {
+	var parsedArgs spinWickSlashCommandArgs
+
+	var outBuf bytes.Buffer
+	flagset := flag.NewFlagSet("spinwick", flag.ContinueOnError)
+	flagset.SetOutput(&outBuf)
+
+	var env string
+	var clearEnv string
+	var size string
+	flagset.StringVar(&env, "env", "", "An optional comma-separated list of environment variables. Example: VAR1=VAl1,VAR2=VAL2")
+	if isUpdate {
+		flagset.StringVar(&clearEnv, "clear-env", "", "An optional comma-separated list of environment variables to clear. Example: VAR1,VAR2")
+	} else {
+		flagset.StringVar(&size, "size", "miniHA", "Size of the Mattermost installation e.g. 'miniSingleton' or 'miniHA'")
+	}
+
+	err := flagset.Parse(args)
+	if errors.Is(err, flag.ErrHelp) {
+		return parsedArgs, outBuf.String(), err
+	} else if err != nil {
+		return parsedArgs, outBuf.String(), fmt.Errorf("failed to parse args: %w", err)
+	}
+
+	s.Logger.WithField("env", env).Info("parsed env vars")
+
+	envMap := make(cloudModel.EnvVarMap)
+	if env != "" {
+		envMap, err = parseEnvArg(env)
+		if err != nil {
+			return parsedArgs, err.Error(), fmt.Errorf("failed to parse env vars: %w", err)
+		}
+	}
+
+	if clearEnv != "" {
+		keys := splitCommaSeparated(clearEnv)
+		for _, k := range keys {
+			envMap[k] = cloudModel.EnvVar{}
+		}
+	}
+
+	parsedArgs.envMap = envMap
+	parsedArgs.size = size
+
+	return parsedArgs, "", nil
+}
+
+var spinwickSlashCommandUsageString = `Usage: /spinwick <command> [args]
+
+Available commands:
+  create  Create a new Mattermost spinwick installation
+  update  Update the existing Mattermost spinwick installation
+  delete  Delete the existing Mattermost spinwick installation
+`
+
+func (s *Server) handleSpinWickSlashCommand(args []string, handlers spinWickSlashCommandsHandlers) (string, error) {
+	if len(args) == 0 {
+		// return help
+		return spinwickSlashCommandUsageString, nil
+	}
+
+	switch args[0] {
+	case "create":
+		s.Logger.WithField("args", args).Info("handling spinwick create command")
+
+		parsedArgs, output, err := s.parseSpinwickSlashCommandArgs(args[1:], false)
+		if err != nil {
+			return output, fmt.Errorf("failed to parse spinwick command args: %w", err)
+		}
+
+		if handlers.createHandler == nil {
+			return "", fmt.Errorf("nil handler")
+		}
+
+		s.Logger.WithFields(logrus.Fields{
+			"envMap": parsedArgs.envMap,
+			"size":   parsedArgs.size,
+		}).Info("going to create spinwick")
+
+		handlers.createHandler(parsedArgs.envMap, parsedArgs.size)
+	case "update":
+		s.Logger.WithField("args", args).Info("handling spinwick update command")
+
+		parsedArgs, output, err := s.parseSpinwickSlashCommandArgs(args[1:], true)
+		if err != nil {
+			return output, fmt.Errorf("failed to parse spinwick command args: %w", err)
+		}
+
+		if handlers.updateHandler == nil {
+			return "", fmt.Errorf("nil handler")
+		}
+
+		s.Logger.WithFields(logrus.Fields{
+			"envMap": parsedArgs.envMap,
+		}).Info("going to update spinwick")
+
+		handlers.updateHandler(parsedArgs.envMap)
+	case "delete":
+		s.Logger.WithField("args", args).Info("handling spinwick delete command")
+
+		if handlers.deleteHandler == nil {
+			return "", fmt.Errorf("nil handler")
+		}
+
+		s.Logger.Info("going to delete spinwick")
+
+		handlers.deleteHandler()
+	default:
+		return spinwickSlashCommandUsageString, fmt.Errorf("invalid command %q", args[0])
+	}
+
+	return "", nil
+}

--- a/server/slash_commands_test.go
+++ b/server/slash_commands_test.go
@@ -1,0 +1,141 @@
+package server
+
+import (
+	"testing"
+
+	cloudModel "github.com/mattermost/mattermost-cloud/model"
+	"github.com/sirupsen/logrus"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestHandleSpinWickSlashCommand(t *testing.T) {
+	logger := logrus.New()
+	s := &Server{
+		Logger: logger,
+	}
+
+	tests := []struct {
+		name          string
+		args          []string
+		expectedErr   string
+		expectedOut   string
+		validateCalls func(t *testing.T, createCalled bool, createEnv cloudModel.EnvVarMap, createSize string,
+			updateCalled bool, updateEnv cloudModel.EnvVarMap,
+			deleteCalled bool)
+	}{
+		{
+			name:        "help command",
+			args:        []string{},
+			expectedOut: spinwickSlashCommandUsageString,
+		},
+		{
+			name: "create command with env vars and size",
+			args: []string{"create", "--env", "VAR1=val1,VAR2=val2", "--size", "miniSingleton"},
+			validateCalls: func(t *testing.T, createCalled bool, createEnv cloudModel.EnvVarMap, createSize string,
+				updateCalled bool, updateEnv cloudModel.EnvVarMap,
+				deleteCalled bool,
+			) {
+				assert.True(t, createCalled)
+				assert.Equal(t, "miniSingleton", createSize)
+				assert.Equal(t, cloudModel.EnvVarMap{
+					"VAR1": cloudModel.EnvVar{Value: "val1"},
+					"VAR2": cloudModel.EnvVar{Value: "val2"},
+				}, createEnv)
+				assert.False(t, updateCalled)
+				assert.False(t, deleteCalled)
+			},
+		},
+		{
+			name: "update command with env vars",
+			args: []string{"update", "--env", "VAR3=val3"},
+			validateCalls: func(t *testing.T, createCalled bool, createEnv cloudModel.EnvVarMap, createSize string,
+				updateCalled bool, updateEnv cloudModel.EnvVarMap,
+				deleteCalled bool,
+			) {
+				assert.False(t, createCalled)
+				assert.True(t, updateCalled)
+				assert.Equal(t, cloudModel.EnvVarMap{
+					"VAR3": cloudModel.EnvVar{Value: "val3"},
+				}, updateEnv)
+				assert.False(t, deleteCalled)
+			},
+		},
+		{
+			name: "update command with clear env",
+			args: []string{"update", "--clear-env", "VAR3"},
+			validateCalls: func(t *testing.T, createCalled bool, createEnv cloudModel.EnvVarMap, createSize string,
+				updateCalled bool, updateEnv cloudModel.EnvVarMap,
+				deleteCalled bool,
+			) {
+				assert.False(t, createCalled)
+				assert.True(t, updateCalled)
+				assert.Equal(t, cloudModel.EnvVarMap{
+					"VAR3": cloudModel.EnvVar{},
+				}, updateEnv)
+				assert.False(t, deleteCalled)
+			},
+		},
+		{
+			name: "delete command",
+			args: []string{"delete"},
+			validateCalls: func(t *testing.T, createCalled bool, createEnv cloudModel.EnvVarMap, createSize string,
+				updateCalled bool, updateEnv cloudModel.EnvVarMap,
+				deleteCalled bool,
+			) {
+				assert.False(t, createCalled)
+				assert.False(t, updateCalled)
+				assert.True(t, deleteCalled)
+			},
+		},
+		{
+			name:        "invalid command",
+			args:        []string{"invalid"},
+			expectedErr: `invalid command "invalid"`,
+		},
+		{
+			name:        "invalid flag",
+			args:        []string{"create", "--invalid-flag"},
+			expectedErr: "failed to parse spinwick command args: failed to parse args: flag provided but not defined: -invalid-flag",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var createCalled bool
+			var createEnv cloudModel.EnvVarMap
+			var createSize string
+			var updateCalled bool
+			var updateEnv cloudModel.EnvVarMap
+			var deleteCalled bool
+
+			handlers := spinWickSlashCommandsHandlers{
+				createHandler: func(envMap cloudModel.EnvVarMap, size string) {
+					createCalled = true
+					createEnv = envMap
+					createSize = size
+				},
+				updateHandler: func(envMap cloudModel.EnvVarMap) {
+					updateCalled = true
+					updateEnv = envMap
+				},
+				deleteHandler: func() {
+					deleteCalled = true
+				},
+			}
+
+			output, err := s.handleSpinWickSlashCommand(tt.args, handlers)
+			if tt.expectedErr != "" {
+				require.Error(t, err)
+				assert.Contains(t, err.Error(), tt.expectedErr)
+				return
+			}
+			require.NoError(t, err)
+			assert.Equal(t, tt.expectedOut, output)
+
+			if tt.validateCalls != nil {
+				tt.validateCalls(t, createCalled, createEnv, createSize, updateCalled, updateEnv, deleteCalled)
+			}
+		})
+	}
+}

--- a/server/utils.go
+++ b/server/utils.go
@@ -2,7 +2,9 @@ package server
 
 import (
 	"fmt"
+	"strings"
 
+	cloudModel "github.com/mattermost/mattermost-cloud/model"
 	"github.com/mattermost/matterwick/model"
 	"github.com/sirupsen/logrus"
 )
@@ -68,3 +70,51 @@ func NewInt32(n int32) *int32 { return &n }
 
 // NewString return a string pointer
 func NewString(s string) *string { return &s }
+
+// splitCommaSeparated splits a comma separated string into a slice of strings
+func splitCommaSeparated(s string) []string {
+	// Unquoting the string
+	s, _ = strings.CutPrefix(s, `'`)
+	s, _ = strings.CutSuffix(s, `'`)
+	s, _ = strings.CutPrefix(s, `"`)
+	s, _ = strings.CutSuffix(s, `"`)
+
+	return strings.Split(strings.TrimSpace(s), ",")
+}
+
+// parseEnvArg parses a string argument in the comma separated format "VAR1=VAL1,VAR2=VAL2" into a cloudModel.EnvVarMap
+func parseEnvArg(arg string) (cloudModel.EnvVarMap, error) {
+	if arg == "" {
+		return nil, fmt.Errorf("invalid empty argument")
+	}
+
+	kvs := splitCommaSeparated(arg)
+	if len(kvs) == 0 {
+		return nil, fmt.Errorf("no key/val pairs found")
+	}
+
+	m := cloudModel.EnvVarMap{}
+	for _, kv := range kvs {
+		fields := strings.SplitN(kv, "=", 2)
+
+		if len(fields) != 2 {
+			return nil, fmt.Errorf("invalid key/val pair: %q", kv)
+		}
+
+		k := strings.TrimSpace(fields[0])
+
+		if k == "" {
+			return nil, fmt.Errorf("invalid key/val pair: %q", kv)
+		}
+
+		v := fields[1]
+
+		if _, ok := m[k]; ok {
+			return nil, fmt.Errorf("duplicate key: %q", k)
+		}
+
+		m[k] = cloudModel.EnvVar{Value: v}
+	}
+
+	return m, nil
+}

--- a/server/utils.go
+++ b/server/utils.go
@@ -71,15 +71,32 @@ func NewInt32(n int32) *int32 { return &n }
 // NewString return a string pointer
 func NewString(s string) *string { return &s }
 
-// splitCommaSeparated splits a comma separated string into a slice of strings
+// splitCommaSeparated splits a comma separated string into a slice of strings.
+// It handles quoted strings and trims whitespace from the results.
 func splitCommaSeparated(s string) []string {
-	// Unquoting the string
-	s, _ = strings.CutPrefix(s, `'`)
-	s, _ = strings.CutSuffix(s, `'`)
-	s, _ = strings.CutPrefix(s, `"`)
-	s, _ = strings.CutSuffix(s, `"`)
+	if s == "" {
+		return nil
+	}
 
-	return strings.Split(strings.TrimSpace(s), ",")
+	// Remove outer quotes if present
+	s = strings.TrimSpace(s)
+	if (strings.HasPrefix(s, "'") && strings.HasSuffix(s, "'")) ||
+		(strings.HasPrefix(s, `"`) && strings.HasSuffix(s, `"`)) {
+		s = s[1 : len(s)-1]
+	}
+
+	// Split and clean the parts
+	parts := strings.Split(s, ",")
+	result := make([]string, 0, len(parts))
+	
+	for _, part := range parts {
+		part = strings.TrimSpace(part)
+		if part != "" {
+			result = append(result, part)
+		}
+	}
+
+	return result
 }
 
 // parseEnvArg parses a string argument in the comma separated format "VAR1=VAL1,VAR2=VAL2" into a cloudModel.EnvVarMap

--- a/server/utils_test.go
+++ b/server/utils_test.go
@@ -7,6 +7,60 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+func TestSplitCommaSeparated(t *testing.T) {
+	for _, tc := range []struct {
+		name     string
+		input    string
+		expected []string
+	}{
+		{
+			name:     "empty string",
+			input:    "",
+			expected: nil,
+		},
+		{
+			name:     "single value",
+			input:    "value1",
+			expected: []string{"value1"},
+		},
+		{
+			name:     "multiple values",
+			input:    "value1,value2,value3",
+			expected: []string{"value1", "value2", "value3"},
+		},
+		{
+			name:     "with spaces",
+			input:    "value1, value2 , value3",
+			expected: []string{"value1", "value2", "value3"},
+		},
+		{
+			name:     "single quoted",
+			input:    "'value1,value2'",
+			expected: []string{"value1", "value2"},
+		},
+		{
+			name:     "double quoted",
+			input:    `"value1,value2"`,
+			expected: []string{"value1", "value2"},
+		},
+		{
+			name:     "empty values filtered",
+			input:    "value1,,value2, ,value3",
+			expected: []string{"value1", "value2", "value3"},
+		},
+		{
+			name:     "whitespace only values filtered",
+			input:    "value1, ,  ,value2",
+			expected: []string{"value1", "value2"},
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			result := splitCommaSeparated(tc.input)
+			require.Equal(t, tc.expected, result)
+		})
+	}
+}
+
 func TestParseEnvVars(t *testing.T) {
 	for _, tc := range []struct {
 		name     string

--- a/server/utils_test.go
+++ b/server/utils_test.go
@@ -1,0 +1,83 @@
+package server
+
+import (
+	"testing"
+
+	cloudModel "github.com/mattermost/mattermost-cloud/model"
+	"github.com/stretchr/testify/require"
+)
+
+func TestParseEnvVars(t *testing.T) {
+	for _, tc := range []struct {
+		name     string
+		input    string
+		expected cloudModel.EnvVarMap
+		err      string
+	}{
+		{
+			name:  "empty",
+			input: "",
+			err:   "invalid empty argument",
+		},
+		{
+			name:  "invalid",
+			input: "invalid",
+			err:   "invalid key/val pair: \"invalid\"",
+		},
+		{
+			name:  "duplicate key",
+			input: "VAR1=VAL1,VAR1=VAL2",
+			err:   "duplicate key: \"VAR1\"",
+		},
+		{
+			name:  "single key/val",
+			input: "VAR1=VAL1",
+			expected: cloudModel.EnvVarMap{
+				"VAR1": cloudModel.EnvVar{Value: "VAL1"},
+			},
+		},
+		{
+			name:  "equal sign in value",
+			input: "VAR1=VAL=1",
+			expected: cloudModel.EnvVarMap{
+				"VAR1": cloudModel.EnvVar{Value: "VAL=1"},
+			},
+		},
+		{
+			name:  "multiple key/val",
+			input: "VAR1=VAL1,VAR2=VAL2,VAR3=VAL3",
+			expected: cloudModel.EnvVarMap{
+				"VAR1": cloudModel.EnvVar{Value: "VAL1"},
+				"VAR2": cloudModel.EnvVar{Value: "VAL2"},
+				"VAR3": cloudModel.EnvVar{Value: "VAL3"},
+			},
+		},
+		{
+			name:  "spaced key/val",
+			input: "VAR1=VAL1, VAR2=VAL2, VAR3=VAL3",
+			expected: cloudModel.EnvVarMap{
+				"VAR1": cloudModel.EnvVar{Value: "VAL1"},
+				"VAR2": cloudModel.EnvVar{Value: "VAL2"},
+				"VAR3": cloudModel.EnvVar{Value: "VAL3"},
+			},
+		},
+		{
+			name:  "quoted string",
+			input: "'VAR1=VAL1'",
+			expected: cloudModel.EnvVarMap{
+				"VAR1": cloudModel.EnvVar{Value: "VAL1"},
+			},
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			parsed, err := parseEnvArg(tc.input)
+			if tc.err != "" {
+				require.EqualError(t, err, tc.err)
+				require.Empty(t, parsed)
+			} else {
+				require.NoError(t, err)
+				require.Equal(t, tc.expected, parsed)
+			}
+		})
+	}
+}

--- a/server/webhook.go
+++ b/server/webhook.go
@@ -7,7 +7,7 @@ import (
 	"bytes"
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 )
 
@@ -36,7 +36,7 @@ func (s *Server) sendToWebhook(webhookRequest *WebhookRequest) error {
 	}
 
 	if response.StatusCode != http.StatusOK {
-		contents, _ := ioutil.ReadAll(response.Body)
+		contents, _ := io.ReadAll(response.Body)
 		return fmt.Errorf("Received non-200 status code when posting to Mattermost: %v", string(contents))
 	}
 


### PR DESCRIPTION
#### Summary

PR implements a `/spinwick` command to enhance the usability of Spinwick installations from GitHub PRs, especially for testing enterprise (HA) changes, without requiring the more complex flow of setting up Cloud servers. One key functionality missing was the ability to set custom environment variables. 

The PR implements the following:

- `/spinwick create`
  - Creates a new spinwick from the PR's build. It accepts optional `-env` and `-size` arguments.
- `/spinwick update`
  - Updates the running spinwick. It accepts optional `-env` and `-clear-env` arguments.
- `/spinwick delete`
  - Deletes the running spinwick. (it's exactly the same as removing the label).

These commands integrate with the existing label-based implementation, so either can be used. Of course, only the command version allows for passing input (e.g., environment).

With a couple of local overrides, I was able to test most functionality end-to-end in a private Github repository, using:

```sh
MATTERWICK_LOCAL_TESTING=true MATTERWICK_REPO_OVERRIDE="spinwicktest" MATTERWICK_BUILD_OVERRIDE="release-10.4" go run -v .
```

#### Ticket Link

https://mattermost.atlassian.net/browse/MM-62271

#### Release Note

```release-note
Implemented new /spinwick slash command to create, update, and destroy installations.
```
