### PR TITLE
Fix backwards compatibility with non oauth enabled provisioner

### DIFF
--- a/model/cloud_client.go
+++ b/model/cloud_client.go
@@ -6,7 +6,7 @@ import (
 	cloudModel "github.com/mattermost/mattermost-cloud/model"
 )
 
-// NewCloudClientWithOAuth creates a new cloud client with OAuth.
+// NewCloudClient creates a new cloud client with OAuth.
 func NewCloudClient(address, clientID, clientSecret, tokenEndpoint, apiKey string) *cloudModel.Client {
 	var headers map[string]string
 

--- a/model/cloud_client.go
+++ b/model/cloud_client.go
@@ -1,11 +1,25 @@
 package model
 
 import (
+	"os"
+
 	cloudModel "github.com/mattermost/mattermost-cloud/model"
 )
 
 // NewCloudClientWithOAuth creates a new cloud client with OAuth.
-func NewCloudClientWithOAuth(address, clientID, clientSecret, tokenEndpoint string) *cloudModel.Client {
+func NewCloudClientWithOAuth(address, clientID, clientSecret, tokenEndpoint, apiKey string) *cloudModel.Client {
 	var headers map[string]string
+
+	if os.Getenv("MATTERWICK_LOCAL_TESTING") == "true" {
+		return cloudModel.NewClient(address)
+	}
+
+	if clientID != "" && clientSecret != "" && tokenEndpoint != "" {
+		headers = map[string]string{
+			"x-api-key": apiKey,
+		}
+
+		return cloudModel.NewClientWithHeaders(address, headers)
+	}
 	return cloudModel.NewClientWithOAuth(address, headers, clientID, clientSecret, tokenEndpoint)
 }

--- a/model/cloud_client.go
+++ b/model/cloud_client.go
@@ -14,7 +14,7 @@ func NewCloudClient(address, clientID, clientSecret, tokenEndpoint, apiKey strin
 		return cloudModel.NewClient(address)
 	}
 
-	if clientID != "" && clientSecret != "" && tokenEndpoint != "" {
+	if clientID == "" && clientSecret == "" && tokenEndpoint == "" {
 		headers = map[string]string{
 			"x-api-key": apiKey,
 		}

--- a/model/cloud_client.go
+++ b/model/cloud_client.go
@@ -7,7 +7,7 @@ import (
 )
 
 // NewCloudClientWithOAuth creates a new cloud client with OAuth.
-func NewCloudClientWithOAuth(address, clientID, clientSecret, tokenEndpoint, apiKey string) *cloudModel.Client {
+func NewCloudClient(address, clientID, clientSecret, tokenEndpoint, apiKey string) *cloudModel.Client {
 	var headers map[string]string
 
 	if os.Getenv("MATTERWICK_LOCAL_TESTING") == "true" {

--- a/server/server.go
+++ b/server/server.go
@@ -58,9 +58,7 @@ func New(config *MatterwickConfig) *Server {
 		logger.SetFormatter(&logrus.JSONFormatter{})
 	}
 
-	var cloudClient *cloudModel.Client
-
-	cloudClient = model.NewCloudClientWithOAuth(config.ProvisionerServer, config.CloudAuth.ClientID, config.CloudAuth.ClientSecret, config.CloudAuth.TokenEndpoint, config.AWSAPIKey)
+	cloudClient := model.NewCloudClient(config.ProvisionerServer, config.CloudAuth.ClientID, config.CloudAuth.ClientSecret, config.CloudAuth.TokenEndpoint, config.AWSAPIKey)
 
 	s := &Server{
 		Config:          config,

--- a/server/server.go
+++ b/server/server.go
@@ -59,11 +59,8 @@ func New(config *MatterwickConfig) *Server {
 	}
 
 	var cloudClient *cloudModel.Client
-	if os.Getenv("MATTERWICK_LOCAL_TESTING") == "true" {
-		cloudClient = cloudModel.NewClient(config.ProvisionerServer)
-	} else {
-		cloudClient = model.NewCloudClientWithOAuth(config.ProvisionerServer, config.CloudAuth.ClientID, config.CloudAuth.ClientSecret, config.CloudAuth.TokenEndpoint)
-	}
+
+	cloudClient = model.NewCloudClientWithOAuth(config.ProvisionerServer, config.CloudAuth.ClientID, config.CloudAuth.ClientSecret, config.CloudAuth.TokenEndpoint, config.AWSAPIKey)
 
 	s := &Server{
 		Config:          config,


### PR DESCRIPTION
<!-- Thank you for contributing a pull request! Here are a few tips to help you:

1. If this is your first contribution, make sure you've read the Contribution Checklist https://developers.mattermost.com/contribute/getting-started/contribution-checklist/
2. Read our blog post about "Submitting Great PRs" https://developers.mattermost.com/blog/2019-01-24-submitting-great-prs
3. Take a look at other repository specific documentation at https://developers.mattermost.com/contribute
-->

#### Summary
This wasn't backwards compatible with provisioner pre-oauth, which hasn't launched yet, so I've adjusted it to make it so. 

#### Ticket Link
<!--
If this pull request addresses a Help Wanted ticket, please link the relevant GitHub issue, e.g.

  Fixes https://github.com/mattermost/mattermost-server/issues/XXXXX

Otherwise, link the JIRA ticket.
-->

#### Release Note
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

-->

```release-note
None
```
