### PR TITLE
Add existing API key header to full auth client

### DIFF
--- a/model/cloud_client.go
+++ b/model/cloud_client.go
@@ -8,18 +8,18 @@ import (
 
 // NewCloudClient creates a new cloud client with OAuth.
 func NewCloudClient(address, clientID, clientSecret, tokenEndpoint, apiKey string) *cloudModel.Client {
-	var headers map[string]string
-
 	if os.Getenv("MATTERWICK_LOCAL_TESTING") == "true" {
 		return cloudModel.NewClient(address)
 	}
 
-	if clientID == "" && clientSecret == "" && tokenEndpoint == "" {
-		headers = map[string]string{
-			"x-api-key": apiKey,
-		}
+	var headers map[string]string
+	if apiKey != "" {
+		headers = map[string]string{"x-api-key": apiKey}
+	}
 
+	if clientID == "" && clientSecret == "" && tokenEndpoint == "" {
 		return cloudModel.NewClientWithHeaders(address, headers)
 	}
+
 	return cloudModel.NewClientWithOAuth(address, headers, clientID, clientSecret, tokenEndpoint)
 }


### PR DESCRIPTION
When building a client with full authentication we also what to allow for providing the existing API key header if it is set.

```release-note
Add existing API key header to full auth client
```
