### PR TITLE
Fix pick latest server version for e2e plugins

### DIFF
--- a/server/e2e_dryrun_test.go
+++ b/server/e2e_dryrun_test.go
@@ -26,6 +26,7 @@ import (
 	"strings"
 	"sync"
 	"testing"
+	"time"
 
 	gogithub "github.com/google/go-github/v32/github"
 	"github.com/mattermost/matterwick/model"
@@ -1083,6 +1084,39 @@ func TestDryRun_ResolveE2EServerVersion(t *testing.T) {
 		assert.Equal(t, "11.6.0", v2)
 		assert.Equal(t, "11.6.0", v3)
 		assert.Equal(t, 1, callCount, "GitHub API must be called exactly once; subsequent calls use the cache")
+	})
+
+	t.Run("stale cache returned when API fails on refresh", func(t *testing.T) {
+		callCount := 0
+		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			if strings.Contains(r.URL.Path, "/releases") {
+				callCount++
+				if callCount == 1 {
+					w.Header().Set("Content-Type", "application/json")
+					w.WriteHeader(http.StatusOK)
+					_, _ = w.Write([]byte(`[{"tag_name":"v11.6.0","draft":false}]`))
+					return
+				}
+				w.WriteHeader(http.StatusInternalServerError)
+				return
+			}
+			w.WriteHeader(http.StatusNotFound)
+		}))
+		t.Cleanup(srv.Close)
+
+		s := newDryRunServerLatest(t, srv)
+
+		v1 := s.resolveE2EServerVersion() // populates cache with "11.6.0"
+		assert.Equal(t, "11.6.0", v1)
+
+		// Expire the cache so the next call hits the API again.
+		s.e2eVersionCacheLock.Lock()
+		s.e2eVersionCacheTime = s.e2eVersionCacheTime.Add(-2 * time.Hour)
+		s.e2eVersionCacheLock.Unlock()
+
+		v2 := s.resolveE2EServerVersion() // API fails → stale cache returned
+		assert.Equal(t, "11.6.0", v2, "should return last known version when API fails on cache refresh")
+		assert.Equal(t, 2, callCount)
 	})
 
 	t.Run("fallback master is not cached — retried on next call", func(t *testing.T) {

--- a/server/e2e_dryrun_test.go
+++ b/server/e2e_dryrun_test.go
@@ -960,7 +960,7 @@ func TestDryRun_ResolveE2EServerVersion(t *testing.T) {
 		assert.Equal(t, "12.0.0", s.resolveE2EServerVersion())
 	})
 
-	t.Run("RC tags skipped, first stable tag returned with v stripped", func(t *testing.T) {
+	t.Run("RC tags included, highest semver returned", func(t *testing.T) {
 		body := `[
 			{"tag_name":"v11.7.0-rc2","draft":false},
 			{"tag_name":"v11.7.0-rc1","draft":false},
@@ -969,27 +969,27 @@ func TestDryRun_ResolveE2EServerVersion(t *testing.T) {
 		]`
 		srv := mockReleasesServer(t, body, http.StatusOK)
 		s := newDryRunServerLatest(t, srv)
-		assert.Equal(t, "11.6.0", s.resolveE2EServerVersion())
+		assert.Equal(t, "11.7.0-rc2", s.resolveE2EServerVersion())
 	})
 
-	t.Run("beta tags skipped", func(t *testing.T) {
+	t.Run("beta tags included, highest semver returned", func(t *testing.T) {
 		body := `[
 			{"tag_name":"v11.7.0-beta.1","draft":false},
 			{"tag_name":"v11.6.0","draft":false}
 		]`
 		srv := mockReleasesServer(t, body, http.StatusOK)
 		s := newDryRunServerLatest(t, srv)
-		assert.Equal(t, "11.6.0", s.resolveE2EServerVersion())
+		assert.Equal(t, "11.7.0-beta.1", s.resolveE2EServerVersion())
 	})
 
-	t.Run("alpha tags skipped", func(t *testing.T) {
+	t.Run("alpha tags included, highest semver returned", func(t *testing.T) {
 		body := `[
 			{"tag_name":"v11.7.0-alpha.1","draft":false},
 			{"tag_name":"v11.6.0","draft":false}
 		]`
 		srv := mockReleasesServer(t, body, http.StatusOK)
 		s := newDryRunServerLatest(t, srv)
-		assert.Equal(t, "11.6.0", s.resolveE2EServerVersion())
+		assert.Equal(t, "11.7.0-alpha.1", s.resolveE2EServerVersion())
 	})
 
 	t.Run("draft releases skipped", func(t *testing.T) {
@@ -1017,14 +1017,14 @@ func TestDryRun_ResolveE2EServerVersion(t *testing.T) {
 		assert.Equal(t, "11.6.0", s.resolveE2EServerVersion())
 	})
 
-	t.Run("only RCs in list → fallback to master", func(t *testing.T) {
+	t.Run("only RCs in list → returns highest RC", func(t *testing.T) {
 		body := `[
 			{"tag_name":"v11.7.0-rc1","draft":false},
 			{"tag_name":"v11.6.0-rc2","draft":false}
 		]`
 		srv := mockReleasesServer(t, body, http.StatusOK)
 		s := newDryRunServerLatest(t, srv)
-		assert.Equal(t, "master", s.resolveE2EServerVersion())
+		assert.Equal(t, "11.7.0-rc1", s.resolveE2EServerVersion())
 	})
 
 	t.Run("only drafts in list → fallback to master", func(t *testing.T) {
@@ -1046,7 +1046,7 @@ func TestDryRun_ResolveE2EServerVersion(t *testing.T) {
 		assert.Equal(t, "master", s.resolveE2EServerVersion())
 	})
 
-	t.Run("mixed: draft RC then stable", func(t *testing.T) {
+	t.Run("mixed: draft RC then non-draft RC and stable → returns highest non-draft", func(t *testing.T) {
 		body := `[
 			{"tag_name":"v11.7.0-rc1","draft":true},
 			{"tag_name":"v11.7.0-rc1","draft":false},
@@ -1054,22 +1054,21 @@ func TestDryRun_ResolveE2EServerVersion(t *testing.T) {
 		]`
 		srv := mockReleasesServer(t, body, http.StatusOK)
 		s := newDryRunServerLatest(t, srv)
-		assert.Equal(t, "11.6.0", s.resolveE2EServerVersion())
+		assert.Equal(t, "11.7.0-rc1", s.resolveE2EServerVersion())
 	})
 
-	t.Run("prerelease flag skipped even when tag name looks stable", func(t *testing.T) {
-		// GitHub marks v11.6.0 as prerelease=true (unusual but possible).
-		// The prerelease field must take precedence over the tag name check.
+	t.Run("prerelease flag no longer skipped — highest semver returned", func(t *testing.T) {
+		// prerelease flag is ignored; only draft is excluded.
 		body := `[
 			{"tag_name":"v11.6.0","draft":false,"prerelease":true},
 			{"tag_name":"v11.5.0","draft":false,"prerelease":false}
 		]`
 		srv := mockReleasesServer(t, body, http.StatusOK)
 		s := newDryRunServerLatest(t, srv)
-		assert.Equal(t, "11.5.0", s.resolveE2EServerVersion())
+		assert.Equal(t, "11.6.0", s.resolveE2EServerVersion())
 	})
 
-	t.Run("prerelease and rc tag both skipped, stable returned", func(t *testing.T) {
+	t.Run("prerelease flag and rc tag both included, highest semver returned", func(t *testing.T) {
 		body := `[
 			{"tag_name":"v11.7.0","draft":false,"prerelease":true},
 			{"tag_name":"v11.6.1-rc1","draft":false,"prerelease":false},
@@ -1077,7 +1076,7 @@ func TestDryRun_ResolveE2EServerVersion(t *testing.T) {
 		]`
 		srv := mockReleasesServer(t, body, http.StatusOK)
 		s := newDryRunServerLatest(t, srv)
-		assert.Equal(t, "11.6.0", s.resolveE2EServerVersion())
+		assert.Equal(t, "11.7.0", s.resolveE2EServerVersion())
 	})
 
 	t.Run("resolved version is cached — API called only once", func(t *testing.T) {

--- a/server/e2e_dryrun_test.go
+++ b/server/e2e_dryrun_test.go
@@ -972,26 +972,6 @@ func TestDryRun_ResolveE2EServerVersion(t *testing.T) {
 		assert.Equal(t, "11.7.0-rc2", s.resolveE2EServerVersion())
 	})
 
-	t.Run("beta tags included, highest semver returned", func(t *testing.T) {
-		body := `[
-			{"tag_name":"v11.7.0-beta.1","draft":false},
-			{"tag_name":"v11.6.0","draft":false}
-		]`
-		srv := mockReleasesServer(t, body, http.StatusOK)
-		s := newDryRunServerLatest(t, srv)
-		assert.Equal(t, "11.7.0-beta.1", s.resolveE2EServerVersion())
-	})
-
-	t.Run("alpha tags included, highest semver returned", func(t *testing.T) {
-		body := `[
-			{"tag_name":"v11.7.0-alpha.1","draft":false},
-			{"tag_name":"v11.6.0","draft":false}
-		]`
-		srv := mockReleasesServer(t, body, http.StatusOK)
-		s := newDryRunServerLatest(t, srv)
-		assert.Equal(t, "11.7.0-alpha.1", s.resolveE2EServerVersion())
-	})
-
 	t.Run("draft releases skipped", func(t *testing.T) {
 		body := `[
 			{"tag_name":"v11.7.0","draft":true},

--- a/server/e2e_dryrun_test.go
+++ b/server/e2e_dryrun_test.go
@@ -884,10 +884,6 @@ func TestDryRun_ConcurrentInstanceAccess(t *testing.T) {
 	// No race detected → concurrent access is safe
 }
 
-// ------------------------------------------------------------
-// 12. resolveE2EServerVersion() — GitHub releases API logic
-// ------------------------------------------------------------
-
 // mockReleasesServer returns an httptest.Server that serves the given body/status
 // for any GET request whose path contains "/releases".
 func mockReleasesServer(t *testing.T, body string, status int) *httptest.Server {
@@ -929,7 +925,7 @@ func TestDryRun_ResolveE2EServerVersion(t *testing.T) {
 			s := newDryRunServer(t, "", "mattermost")
 			s.Config.E2EServerVersion = cfg
 			s.githubAPIBase = srv.URL + "/"
-			assert.Equal(t, cfg, s.resolveE2EServerVersion(), "config=%q should be returned unchanged", cfg)
+			assert.Equal(t, cfg, s.resolveMattermostServerVersion(), "config=%q should be returned unchanged", cfg)
 		}
 		assert.False(t, called, "GitHub API must not be called when E2EServerVersion is not 'latest'")
 	})
@@ -945,7 +941,7 @@ func TestDryRun_ResolveE2EServerVersion(t *testing.T) {
 		s.Config.E2EServerVersion = ""
 		s.githubAPIBase = srv.URL + "/"
 
-		assert.Equal(t, "12.0.0", s.resolveE2EServerVersion(),
+		assert.Equal(t, "12.0.0", s.resolveMattermostServerVersion(),
 			"empty E2EServerVersion must fall back to latest resolution, not return empty")
 	})
 
@@ -958,7 +954,7 @@ func TestDryRun_ResolveE2EServerVersion(t *testing.T) {
 		s.Config.E2EServerVersion = "   "
 		s.githubAPIBase = srv.URL + "/"
 
-		assert.Equal(t, "12.0.0", s.resolveE2EServerVersion())
+		assert.Equal(t, "12.0.0", s.resolveMattermostServerVersion())
 	})
 
 	t.Run("RC tags included, highest semver returned", func(t *testing.T) {
@@ -970,7 +966,34 @@ func TestDryRun_ResolveE2EServerVersion(t *testing.T) {
 		]`
 		srv := mockReleasesServer(t, body, http.StatusOK)
 		s := newDryRunServerLatest(t, srv)
-		assert.Equal(t, "11.7.0-rc2", s.resolveE2EServerVersion())
+		assert.Equal(t, "11.7.0-rc2", s.resolveMattermostServerVersion())
+	})
+
+	t.Run("beta tags skipped, stable returned", func(t *testing.T) {
+		// 12.0.0-beta.1 would beat 11.9.0-rc1 in semver but must be excluded —
+		// beta builds are too early for E2E infra.
+		body := `[
+			{"tag_name":"v12.0.0-beta.1","draft":false},
+			{"tag_name":"v11.9.0-rc1","draft":false},
+			{"tag_name":"v11.8.1","draft":false}
+		]`
+		srv := mockReleasesServer(t, body, http.StatusOK)
+		s := newDryRunServerLatest(t, srv)
+		assert.Equal(t, "11.9.0-rc1", s.resolveMattermostServerVersion())
+	})
+
+	t.Run("alpha tags skipped, RC of lower version returned", func(t *testing.T) {
+		// 12.0.0-alpha.1 would beat 11.9.0-rc1 in semver but must be excluded —
+		// alpha builds are too early for E2E infra. Mattermost published v11.0.0-alpha.1
+		// as a one-off for the major-version announcement; v12.0.0-alpha.1 is plausible.
+		body := `[
+			{"tag_name":"v12.0.0-alpha.1","draft":false},
+			{"tag_name":"v11.9.0-rc1","draft":false},
+			{"tag_name":"v11.8.1","draft":false}
+		]`
+		srv := mockReleasesServer(t, body, http.StatusOK)
+		s := newDryRunServerLatest(t, srv)
+		assert.Equal(t, "11.9.0-rc1", s.resolveMattermostServerVersion())
 	})
 
 	t.Run("draft releases skipped", func(t *testing.T) {
@@ -980,14 +1003,14 @@ func TestDryRun_ResolveE2EServerVersion(t *testing.T) {
 		]`
 		srv := mockReleasesServer(t, body, http.StatusOK)
 		s := newDryRunServerLatest(t, srv)
-		assert.Equal(t, "11.6.0", s.resolveE2EServerVersion())
+		assert.Equal(t, "11.6.0", s.resolveMattermostServerVersion())
 	})
 
 	t.Run("stable release at top of list returned immediately", func(t *testing.T) {
 		body := `[{"tag_name":"v12.0.0","draft":false},{"tag_name":"v11.6.0","draft":false}]`
 		srv := mockReleasesServer(t, body, http.StatusOK)
 		s := newDryRunServerLatest(t, srv)
-		assert.Equal(t, "12.0.0", s.resolveE2EServerVersion())
+		assert.Equal(t, "12.0.0", s.resolveMattermostServerVersion())
 	})
 
 	t.Run("tag without v prefix returned unchanged", func(t *testing.T) {
@@ -995,7 +1018,7 @@ func TestDryRun_ResolveE2EServerVersion(t *testing.T) {
 		body := `[{"tag_name":"11.6.0","draft":false}]`
 		srv := mockReleasesServer(t, body, http.StatusOK)
 		s := newDryRunServerLatest(t, srv)
-		assert.Equal(t, "11.6.0", s.resolveE2EServerVersion())
+		assert.Equal(t, "11.6.0", s.resolveMattermostServerVersion())
 	})
 
 	t.Run("only RCs in list → returns highest RC", func(t *testing.T) {
@@ -1005,26 +1028,26 @@ func TestDryRun_ResolveE2EServerVersion(t *testing.T) {
 		]`
 		srv := mockReleasesServer(t, body, http.StatusOK)
 		s := newDryRunServerLatest(t, srv)
-		assert.Equal(t, "11.7.0-rc1", s.resolveE2EServerVersion())
+		assert.Equal(t, "11.7.0-rc1", s.resolveMattermostServerVersion())
 	})
 
 	t.Run("only drafts in list → fallback to master", func(t *testing.T) {
 		body := `[{"tag_name":"v11.7.0","draft":true}]`
 		srv := mockReleasesServer(t, body, http.StatusOK)
 		s := newDryRunServerLatest(t, srv)
-		assert.Equal(t, "master", s.resolveE2EServerVersion())
+		assert.Equal(t, "master", s.resolveMattermostServerVersion())
 	})
 
 	t.Run("empty releases list → fallback to master", func(t *testing.T) {
 		srv := mockReleasesServer(t, `[]`, http.StatusOK)
 		s := newDryRunServerLatest(t, srv)
-		assert.Equal(t, "master", s.resolveE2EServerVersion())
+		assert.Equal(t, "master", s.resolveMattermostServerVersion())
 	})
 
 	t.Run("API returns 500 → fallback to master", func(t *testing.T) {
 		srv := mockReleasesServer(t, `{"message":"Internal Server Error"}`, http.StatusInternalServerError)
 		s := newDryRunServerLatest(t, srv)
-		assert.Equal(t, "master", s.resolveE2EServerVersion())
+		assert.Equal(t, "master", s.resolveMattermostServerVersion())
 	})
 
 	t.Run("mixed: draft RC then non-draft RC and stable → returns highest non-draft", func(t *testing.T) {
@@ -1035,7 +1058,7 @@ func TestDryRun_ResolveE2EServerVersion(t *testing.T) {
 		]`
 		srv := mockReleasesServer(t, body, http.StatusOK)
 		s := newDryRunServerLatest(t, srv)
-		assert.Equal(t, "11.7.0-rc1", s.resolveE2EServerVersion())
+		assert.Equal(t, "11.7.0-rc1", s.resolveMattermostServerVersion())
 	})
 
 	t.Run("prerelease flag no longer skipped — highest semver returned", func(t *testing.T) {
@@ -1046,7 +1069,7 @@ func TestDryRun_ResolveE2EServerVersion(t *testing.T) {
 		]`
 		srv := mockReleasesServer(t, body, http.StatusOK)
 		s := newDryRunServerLatest(t, srv)
-		assert.Equal(t, "11.6.0", s.resolveE2EServerVersion())
+		assert.Equal(t, "11.6.0", s.resolveMattermostServerVersion())
 	})
 
 	t.Run("prerelease flag and rc tag both included, highest semver returned", func(t *testing.T) {
@@ -1057,7 +1080,7 @@ func TestDryRun_ResolveE2EServerVersion(t *testing.T) {
 		]`
 		srv := mockReleasesServer(t, body, http.StatusOK)
 		s := newDryRunServerLatest(t, srv)
-		assert.Equal(t, "11.7.0", s.resolveE2EServerVersion())
+		assert.Equal(t, "11.7.0", s.resolveMattermostServerVersion())
 	})
 
 	t.Run("resolved version is cached — API called only once", func(t *testing.T) {
@@ -1076,9 +1099,9 @@ func TestDryRun_ResolveE2EServerVersion(t *testing.T) {
 
 		s := newDryRunServerLatest(t, srv)
 
-		v1 := s.resolveE2EServerVersion()
-		v2 := s.resolveE2EServerVersion()
-		v3 := s.resolveE2EServerVersion()
+		v1 := s.resolveMattermostServerVersion()
+		v2 := s.resolveMattermostServerVersion()
+		v3 := s.resolveMattermostServerVersion()
 
 		assert.Equal(t, "11.6.0", v1)
 		assert.Equal(t, "11.6.0", v2)
@@ -1106,7 +1129,7 @@ func TestDryRun_ResolveE2EServerVersion(t *testing.T) {
 
 		s := newDryRunServerLatest(t, srv)
 
-		v1 := s.resolveE2EServerVersion() // populates cache with "11.6.0"
+		v1 := s.resolveMattermostServerVersion() // populates cache with "11.6.0"
 		assert.Equal(t, "11.6.0", v1)
 
 		// Expire the cache so the next call hits the API again.
@@ -1114,7 +1137,7 @@ func TestDryRun_ResolveE2EServerVersion(t *testing.T) {
 		s.e2eVersionCacheTime = s.e2eVersionCacheTime.Add(-2 * time.Hour)
 		s.e2eVersionCacheLock.Unlock()
 
-		v2 := s.resolveE2EServerVersion() // API fails → stale cache returned
+		v2 := s.resolveMattermostServerVersion() // API fails → stale cache returned
 		assert.Equal(t, "11.6.0", v2, "should return last known version when API fails on cache refresh")
 		assert.Equal(t, 2, callCount)
 	})
@@ -1140,9 +1163,9 @@ func TestDryRun_ResolveE2EServerVersion(t *testing.T) {
 
 		s := newDryRunServerLatest(t, srv)
 
-		v1 := s.resolveE2EServerVersion() // API error → fallback "master" (not cached)
-		v2 := s.resolveE2EServerVersion() // retried → "11.6.0" (now cached)
-		v3 := s.resolveE2EServerVersion() // cache hit → "11.6.0"
+		v1 := s.resolveMattermostServerVersion() // API error → fallback "master" (not cached)
+		v2 := s.resolveMattermostServerVersion() // retried → "11.6.0" (now cached)
+		v3 := s.resolveMattermostServerVersion() // cache hit → "11.6.0"
 
 		assert.Equal(t, "master", v1, "first call: API error should fall back to master")
 		assert.Equal(t, "11.6.0", v2, "second call: should retry and resolve correctly")
@@ -1166,10 +1189,8 @@ func TestDryRun_PushEventServerVersion(t *testing.T) {
 		srv := mockReleasesServer(t, body, http.StatusOK)
 		s := newDryRunServerLatest(t, srv)
 
-		assert.Equal(t, "12.0.0", s.serverVersionForPushEvent("release-9.0"),
+		assert.Equal(t, "12.0.0", s.serverVersionForPushEvent(),
 			"release-9.0 push must provision latest server (12.0.0), not branch-derived 9.0")
-		assert.Equal(t, "12.0.0", s.serverVersionForPushEvent("release-10.5"),
-			"release-10.5 push must provision latest server (12.0.0), not branch-derived 10.5")
 	})
 
 	t.Run("master push uses latest version", func(t *testing.T) {
@@ -1177,8 +1198,7 @@ func TestDryRun_PushEventServerVersion(t *testing.T) {
 		srv := mockReleasesServer(t, body, http.StatusOK)
 		s := newDryRunServerLatest(t, srv)
 
-		assert.Equal(t, "12.0.0", s.serverVersionForPushEvent("master"))
-		assert.Equal(t, "12.0.0", s.serverVersionForPushEvent("main"))
+		assert.Equal(t, "12.0.0", s.serverVersionForPushEvent())
 	})
 }
 
@@ -1267,7 +1287,7 @@ func TestDryRun_MMServerVersionFromInstance(t *testing.T) {
 	})
 
 	t.Run("all instances in a PR run share the same resolved version", func(t *testing.T) {
-		// createMultipleE2EInstances calls resolveE2EServerVersion() once and passes
+		// createMultipleE2EInstances calls resolveMattermostServerVersion() once and passes
 		// the same version to all createCloudInstallation calls.
 		resolvedVersion := "11.6.0"
 		platforms := []string{"linux", "macos", "windows"}
@@ -1284,14 +1304,14 @@ func TestDryRun_MMServerVersionFromInstance(t *testing.T) {
 		}
 	})
 
-	t.Run("resolveE2EServerVersion with latest returns Docker Hub compatible version", func(t *testing.T) {
+	t.Run("resolveMattermostServerVersion with latest returns Docker Hub compatible version", func(t *testing.T) {
 		// Docker Hub tags are bare semver (e.g. "11.6.0"), NOT "v11.6.0".
 		// Verify the v-stripping produces a Docker Hub compatible string.
 		body := `[{"tag_name":"v11.6.0","draft":false}]`
 		srv := mockReleasesServer(t, body, http.StatusOK)
 		s := newDryRunServerLatest(t, srv)
 
-		version := s.resolveE2EServerVersion()
+		version := s.resolveMattermostServerVersion()
 		assert.Equal(t, "11.6.0", version)
 		assert.False(t, strings.HasPrefix(version, "v"),
 			"resolved version must NOT have 'v' prefix — Docker Hub tags are bare semver")

--- a/server/e2e_tests.go
+++ b/server/e2e_tests.go
@@ -9,12 +9,10 @@ import (
 	"fmt"
 	"net/url"
 	"os"
-	"sort"
 	"strings"
 	"sync"
 	"time"
 
-	"github.com/blang/semver"
 	"github.com/google/go-github/v32/github"
 	cloudModel "github.com/mattermost/mattermost-cloud/model"
 	mattermostModel "github.com/mattermost/mattermost-server/v6/model"
@@ -231,7 +229,7 @@ func (s *Server) createMultipleE2EInstances(pr *model.PullRequest, instanceType 
 		"platforms": len(platforms),
 	})
 
-	version := s.resolveE2EServerVersion()
+	version := s.resolveMattermostServerVersion()
 	username := s.Config.E2EUsername
 	password := s.getE2EPassword(instanceType)
 	// Name format: {type}-pr-{pr}-{platform}-{hex6}
@@ -771,110 +769,6 @@ func (s *Server) cleanupStaleNonPRE2EInstances() {
 	logger.Info("Non-PR E2E instance cleanup scan complete")
 }
 
-// resolveE2EServerVersion returns the server version for E2E provisioning.
-// "latest" (or empty) fetches all non-draft mattermost/mattermost releases, picks the
-// highest semver (including RCs), strips the "v" prefix, and caches the result for 1 hour.
-// On API error or empty results, returns the last cached version if one exists.
-func (s *Server) resolveE2EServerVersion() string {
-	cfg := strings.TrimSpace(s.Config.E2EServerVersion)
-	if cfg == "" {
-		s.Logger.Warn("[resolveE2EServerVersion] E2EServerVersion is empty in config; defaulting to 'latest'")
-		cfg = "latest"
-	}
-	if cfg != "latest" {
-		return cfg
-	}
-
-	const cacheTTL = 1 * time.Hour
-
-	// Return cached value if still fresh.
-	s.e2eVersionCacheLock.Lock()
-	stale := s.e2eVersionCache
-	if stale != "" && time.Since(s.e2eVersionCacheTime) < cacheTTL {
-		s.e2eVersionCacheLock.Unlock()
-		s.Logger.WithField("version", stale).Debug("[resolveE2EServerVersion] Returning cached version")
-		return stale
-	}
-	s.e2eVersionCacheLock.Unlock()
-
-	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
-	defer cancel()
-
-	client := newGithubClient(s.Config.GithubAccessToken)
-
-	// githubAPIBase is only set in tests to redirect to a mock server.
-	if s.githubAPIBase != "" {
-		if baseURL, parseErr := url.Parse(s.githubAPIBase); parseErr == nil {
-			client.BaseURL = baseURL
-		}
-	}
-
-	var releases []struct {
-		TagName string `json:"tag_name"`
-		Draft   bool   `json:"draft"`
-	}
-
-	req, err := client.NewRequest("GET", "/repos/mattermost/mattermost/releases?per_page=20", nil)
-	if err != nil {
-		s.Logger.WithError(err).Warn("[resolveE2EServerVersion] Failed to build request")
-		if stale != "" {
-			s.Logger.WithField("version", stale).Warn("[resolveE2EServerVersion] Using last known version")
-			return stale
-		}
-		return "master"
-	}
-	if _, err = client.Do(ctx, req, &releases); err != nil {
-		s.Logger.WithError(err).Warn("[resolveE2EServerVersion] Failed to fetch releases")
-		if stale != "" {
-			s.Logger.WithField("version", stale).Warn("[resolveE2EServerVersion] Using last known version")
-			return stale
-		}
-		return "master"
-	}
-
-	// Collect all parseable non-draft releases and sort by semver descending
-	// so the highest version wins regardless of GitHub's publish-date ordering.
-	type candidate struct {
-		tag string
-		ver semver.Version
-	}
-	var candidates []candidate
-	for _, r := range releases {
-		if r.Draft {
-			continue
-		}
-		raw := strings.TrimPrefix(r.TagName, "v")
-		v, parseErr := semver.ParseTolerant(raw)
-		if parseErr != nil {
-			continue
-		}
-		candidates = append(candidates, candidate{tag: raw, ver: v})
-	}
-
-	if len(candidates) == 0 {
-		s.Logger.Warn("[resolveE2EServerVersion] No release found")
-		if stale != "" {
-			s.Logger.WithField("version", stale).Warn("[resolveE2EServerVersion] Using last known version")
-			return stale
-		}
-		return "master"
-	}
-
-	sort.Slice(candidates, func(i, j int) bool {
-		return candidates[i].ver.GT(candidates[j].ver)
-	})
-
-	version := candidates[0].tag
-	s.Logger.WithField("version", version).Info("[resolveE2EServerVersion] Resolved latest Mattermost server version")
-
-	s.e2eVersionCacheLock.Lock()
-	s.e2eVersionCache = version
-	s.e2eVersionCacheTime = time.Now()
-	s.e2eVersionCacheLock.Unlock()
-
-	return version
-}
-
 // destroyE2EInstances destroys all given E2E instances
 func (s *Server) destroyE2EInstances(instances []*E2EInstance, logger logrus.FieldLogger) {
 	for _, instance := range instances {
@@ -1092,7 +986,7 @@ func (s *Server) dispatchDesktopE2EWorkflow(repoOwner, repoName, ref, sha, insta
 	// Determine the server version to use for the workflow.
 	// Default to the configured E2E server version, but prefer the actual
 	// provisioned version from the instance details when available.
-	serverVersion := s.resolveE2EServerVersion()
+	serverVersion := s.resolveMattermostServerVersion()
 	if instanceDetailsJSON != "" {
 		var instances []struct {
 			ServerVersion string `json:"server_version"`

--- a/server/e2e_tests.go
+++ b/server/e2e_tests.go
@@ -9,10 +9,12 @@ import (
 	"fmt"
 	"net/url"
 	"os"
+	"sort"
 	"strings"
 	"sync"
 	"time"
 
+	"github.com/blang/semver"
 	"github.com/google/go-github/v32/github"
 	cloudModel "github.com/mattermost/mattermost-cloud/model"
 	mattermostModel "github.com/mattermost/mattermost-server/v6/model"
@@ -770,9 +772,9 @@ func (s *Server) cleanupStaleNonPRE2EInstances() {
 }
 
 // resolveE2EServerVersion returns the server version for E2E provisioning.
-// "latest" (or empty) fetches the newest stable mattermost/mattermost release — skips
-// drafts, prereleases, and RC/beta/alpha tags — strips the "v" prefix, and caches the
-// result for 1 hour. Falls back to "master" on API error or if no stable release is found.
+// "latest" (or empty) fetches all non-draft mattermost/mattermost releases, picks the
+// highest semver (including RCs), strips the "v" prefix, and caches the result for 1 hour.
+// On API error or empty results, returns the last cached version if one exists.
 func (s *Server) resolveE2EServerVersion() string {
 	cfg := strings.TrimSpace(s.Config.E2EServerVersion)
 	if cfg == "" {
@@ -787,11 +789,11 @@ func (s *Server) resolveE2EServerVersion() string {
 
 	// Return cached value if still fresh.
 	s.e2eVersionCacheLock.Lock()
-	if s.e2eVersionCache != "" && time.Since(s.e2eVersionCacheTime) < cacheTTL {
-		cached := s.e2eVersionCache
+	stale := s.e2eVersionCache
+	if stale != "" && time.Since(s.e2eVersionCacheTime) < cacheTTL {
 		s.e2eVersionCacheLock.Unlock()
-		s.Logger.WithField("version", cached).Debug("[resolveE2EServerVersion] Returning cached version")
-		return cached
+		s.Logger.WithField("version", stale).Debug("[resolveE2EServerVersion] Returning cached version")
+		return stale
 	}
 	s.e2eVersionCacheLock.Unlock()
 
@@ -808,43 +810,69 @@ func (s *Server) resolveE2EServerVersion() string {
 	}
 
 	var releases []struct {
-		TagName    string `json:"tag_name"`
-		Draft      bool   `json:"draft"`
-		Prerelease bool   `json:"prerelease"`
+		TagName string `json:"tag_name"`
+		Draft   bool   `json:"draft"`
 	}
 
 	req, err := client.NewRequest("GET", "/repos/mattermost/mattermost/releases?per_page=20", nil)
 	if err != nil {
-		s.Logger.WithError(err).Warn("[resolveE2EServerVersion] Failed to build request, falling back to master")
+		s.Logger.WithError(err).Warn("[resolveE2EServerVersion] Failed to build request")
+		if stale != "" {
+			s.Logger.WithField("version", stale).Warn("[resolveE2EServerVersion] Using last known version")
+			return stale
+		}
 		return "master"
 	}
 	if _, err = client.Do(ctx, req, &releases); err != nil {
-		s.Logger.WithError(err).Warn("[resolveE2EServerVersion] Failed to fetch releases, falling back to master")
+		s.Logger.WithError(err).Warn("[resolveE2EServerVersion] Failed to fetch releases")
+		if stale != "" {
+			s.Logger.WithField("version", stale).Warn("[resolveE2EServerVersion] Using last known version")
+			return stale
+		}
 		return "master"
 	}
 
+	// Collect all parseable non-draft releases and sort by semver descending
+	// so the highest version wins regardless of GitHub's publish-date ordering.
+	type candidate struct {
+		tag string
+		ver semver.Version
+	}
+	var candidates []candidate
 	for _, r := range releases {
-		if r.Draft || r.Prerelease {
+		if r.Draft {
 			continue
 		}
-		// Secondary guard: some RC tags don't have the prerelease flag set correctly.
-		lower := strings.ToLower(r.TagName)
-		if strings.Contains(lower, "-rc") || strings.Contains(lower, "-beta") || strings.Contains(lower, "-alpha") {
+		raw := strings.TrimPrefix(r.TagName, "v")
+		v, parseErr := semver.ParseTolerant(raw)
+		if parseErr != nil {
 			continue
 		}
-		version := strings.TrimPrefix(r.TagName, "v") // Docker Hub uses "11.6.0" not "v11.6.0"
-		s.Logger.WithField("version", version).Info("[resolveE2EServerVersion] Resolved latest Mattermost server version")
-
-		s.e2eVersionCacheLock.Lock()
-		s.e2eVersionCache = version
-		s.e2eVersionCacheTime = time.Now()
-		s.e2eVersionCacheLock.Unlock()
-
-		return version
+		candidates = append(candidates, candidate{tag: raw, ver: v})
 	}
 
-	s.Logger.Warn("[resolveE2EServerVersion] No stable release found, falling back to master")
-	return "master"
+	if len(candidates) == 0 {
+		s.Logger.Warn("[resolveE2EServerVersion] No release found")
+		if stale != "" {
+			s.Logger.WithField("version", stale).Warn("[resolveE2EServerVersion] Using last known version")
+			return stale
+		}
+		return "master"
+	}
+
+	sort.Slice(candidates, func(i, j int) bool {
+		return candidates[i].ver.GT(candidates[j].ver)
+	})
+
+	version := candidates[0].tag
+	s.Logger.WithField("version", version).Info("[resolveE2EServerVersion] Resolved latest Mattermost server version")
+
+	s.e2eVersionCacheLock.Lock()
+	s.e2eVersionCache = version
+	s.e2eVersionCacheTime = time.Now()
+	s.e2eVersionCacheLock.Unlock()
+
+	return version
 }
 
 // destroyE2EInstances destroys all given E2E instances

--- a/server/push_events.go
+++ b/server/push_events.go
@@ -68,11 +68,8 @@ func (s *Server) isReleaseBranch(branch string) bool {
 	return strings.HasPrefix(branch, s.Config.E2EReleasePatternPrefix)
 }
 
-// serverVersionForPushEvent resolves the server version via resolveE2EServerVersion.
-// Branch name is ignored — derived names like "9.0" don't exist as Docker Hub tags ("9.0.0").
-func (s *Server) serverVersionForPushEvent(branch string) string {
-	_ = branch
-	return s.resolveE2EServerVersion()
+func (s *Server) serverVersionForPushEvent() string {
+	return s.resolveMattermostServerVersion()
 }
 
 // extractBranchName extracts the branch name from "refs/heads/branch-name".
@@ -169,7 +166,7 @@ func (s *Server) createMultipleE2EInstancesForPushEvent(repoName, instanceType, 
 		"platformCount": len(platforms),
 	})
 
-	serverVersion := s.serverVersionForPushEvent(branch)
+	serverVersion := s.serverVersionForPushEvent()
 	sanitizedVersion := sanitizeForDNS(serverVersion)
 	uid := e2eUniqueSuffix()
 

--- a/server/spinwick_plugin.go
+++ b/server/spinwick_plugin.go
@@ -18,11 +18,10 @@ import (
 )
 
 const (
-	defaultPluginImage   = "mattermostdevelopment/mattermost-enterprise-edition"
-	defaultPluginVersion = "master"
-	pluginRepoPrefix     = "mattermost-plugin-"
-	pluginS3Bucket       = "mattermost-plugin-pr-builds"
-	pluginS3Region       = "us-east-1" // Adjust if needed
+	defaultPluginImage = "mattermostdevelopment/mattermost-enterprise-edition"
+	pluginRepoPrefix   = "mattermost-plugin-"
+	pluginS3Bucket     = "mattermost-plugin-pr-builds"
+	pluginS3Region     = "us-east-1"
 )
 
 // isPluginRepository checks if the repository is a plugin repository
@@ -60,11 +59,13 @@ func (s *Server) createPluginSpinWick(pr *model.PullRequest, logger logrus.Field
 
 	logger.Info("No plugin SpinWick found for this PR. Creating a new one.")
 
-	// Create the Mattermost installation
+	// Create the Mattermost installation using the latest stable server version
 	cloudClient := s.CloudClient
+	serverVersion := s.resolveE2EServerVersion()
+	logger.WithField("server_version", serverVersion).Info("Resolved Mattermost server version for plugin SpinWick")
 	installationRequest := s.createInstallationRequest(
 		ownerID,
-		defaultPluginVersion,
+		serverVersion,
 		defaultPluginImage,
 		spinwick.DNS(s.Config.DNSNameTestServer),
 		"miniSingleton",

--- a/server/spinwick_plugin.go
+++ b/server/spinwick_plugin.go
@@ -59,7 +59,7 @@ func (s *Server) createPluginSpinWick(pr *model.PullRequest, logger logrus.Field
 
 	logger.Info("No plugin SpinWick found for this PR. Creating a new one.")
 
-	// Create the Mattermost installation using the latest stable server version
+	// Create the Mattermost installation using the highest available server version (including RCs)
 	cloudClient := s.CloudClient
 	serverVersion := s.resolveE2EServerVersion()
 	logger.WithField("server_version", serverVersion).Info("Resolved Mattermost server version for plugin SpinWick")

--- a/server/spinwick_plugin.go
+++ b/server/spinwick_plugin.go
@@ -61,7 +61,7 @@ func (s *Server) createPluginSpinWick(pr *model.PullRequest, logger logrus.Field
 
 	// Create the Mattermost installation using the highest available server version (including RCs)
 	cloudClient := s.CloudClient
-	serverVersion := s.resolveE2EServerVersion()
+	serverVersion := s.resolveMattermostServerVersion()
 	logger.WithField("server_version", serverVersion).Info("Resolved Mattermost server version for plugin SpinWick")
 	installationRequest := s.createInstallationRequest(
 		ownerID,

--- a/server/spinwick_plugin_test.go
+++ b/server/spinwick_plugin_test.go
@@ -300,7 +300,6 @@ func TestIntegrationScenarios(t *testing.T) {
 // TestConstants verifies that our constants are set correctly
 func TestConstants(t *testing.T) {
 	assert.Equal(t, "mattermostdevelopment/mattermost-enterprise-edition", defaultPluginImage)
-	assert.Equal(t, "master", defaultPluginVersion)
 	assert.Equal(t, "mattermost-plugin-", pluginRepoPrefix)
 	assert.Equal(t, "mattermost-plugin-pr-builds", pluginS3Bucket)
 	assert.Equal(t, "us-east-1", pluginS3Region)

--- a/server/version.go
+++ b/server/version.go
@@ -5,6 +5,7 @@ package server
 
 import (
 	"context"
+	"fmt"
 	"net/url"
 	"sort"
 	"strings"
@@ -49,19 +50,27 @@ func (s *Server) resolveMattermostServerVersion() string {
 		}
 	}
 
-	var releases []struct {
+	type releaseEntry struct {
 		TagName string `json:"tag_name"`
 		Draft   bool   `json:"draft"`
 	}
-
-	req, err := client.NewRequest("GET", "/repos/mattermost/mattermost/releases?per_page=100", nil)
-	if err != nil {
-		s.Logger.WithError(err).Warn("[resolveMattermostServerVersion] Failed to build request")
-		return s.cachedVersionOrMaster()
-	}
-	if _, err = client.Do(ctx, req, &releases); err != nil {
-		s.Logger.WithError(err).Warn("[resolveMattermostServerVersion] Failed to fetch releases")
-		return s.cachedVersionOrMaster()
+	const perPage = 100
+	var releases []releaseEntry
+	for page := 1; ; page++ {
+		req, err := client.NewRequest("GET", fmt.Sprintf("/repos/mattermost/mattermost/releases?per_page=%d&page=%d", perPage, page), nil)
+		if err != nil {
+			s.Logger.WithError(err).Warn("[resolveMattermostServerVersion] Failed to build request")
+			return s.cachedVersionOrMaster()
+		}
+		var pageReleases []releaseEntry
+		if _, err = client.Do(ctx, req, &pageReleases); err != nil {
+			s.Logger.WithError(err).Warn("[resolveMattermostServerVersion] Failed to fetch releases")
+			return s.cachedVersionOrMaster()
+		}
+		releases = append(releases, pageReleases...)
+		if len(pageReleases) < perPage {
+			break
+		}
 	}
 
 	// Sort by semver descending; GitHub's publish-date order can put backport patches ahead of newer minors.

--- a/server/version.go
+++ b/server/version.go
@@ -1,0 +1,119 @@
+// Copyright (c) 2020-present Mattermost, Inc. All Rights Reserved.
+// See License.txt for license information.
+
+package server
+
+import (
+	"context"
+	"net/url"
+	"sort"
+	"strings"
+	"time"
+
+	"github.com/blang/semver"
+)
+
+// resolveMattermostServerVersion returns the highest non-alpha/beta release (stable or RC)
+// from mattermost/mattermost, cached for 1 hour. Falls back to the last cached version on error.
+func (s *Server) resolveMattermostServerVersion() string {
+	cfg := strings.TrimSpace(s.Config.E2EServerVersion)
+	if cfg == "" {
+		s.Logger.Warn("[resolveMattermostServerVersion] E2EServerVersion is empty in config; defaulting to 'latest'")
+		cfg = "latest"
+	}
+	if cfg != "latest" {
+		return cfg
+	}
+
+	const cacheTTL = 1 * time.Hour
+
+	// Fast path: return the cached version if still fresh.
+	s.e2eVersionCacheLock.Lock()
+	if s.e2eVersionCache != "" && time.Since(s.e2eVersionCacheTime) < cacheTTL {
+		v := s.e2eVersionCache
+		s.e2eVersionCacheLock.Unlock()
+		s.Logger.WithField("version", v).Debug("[resolveMattermostServerVersion] Returning cached version")
+		return v
+	}
+	s.e2eVersionCacheLock.Unlock()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	client := newGithubClient(s.Config.GithubAccessToken)
+
+	// githubAPIBase is only set in tests to point to a mock server.
+	if s.githubAPIBase != "" {
+		if baseURL, parseErr := url.Parse(s.githubAPIBase); parseErr == nil {
+			client.BaseURL = baseURL
+		}
+	}
+
+	var releases []struct {
+		TagName string `json:"tag_name"`
+		Draft   bool   `json:"draft"`
+	}
+
+	req, err := client.NewRequest("GET", "/repos/mattermost/mattermost/releases?per_page=100", nil)
+	if err != nil {
+		s.Logger.WithError(err).Warn("[resolveMattermostServerVersion] Failed to build request")
+		return s.cachedVersionOrMaster()
+	}
+	if _, err = client.Do(ctx, req, &releases); err != nil {
+		s.Logger.WithError(err).Warn("[resolveMattermostServerVersion] Failed to fetch releases")
+		return s.cachedVersionOrMaster()
+	}
+
+	// Sort by semver descending; GitHub's publish-date order can put backport patches ahead of newer minors.
+	// Skip alpha/beta — a future v12.0.0-alpha.1 would otherwise rank above v11.9.0-rc1.
+	type candidate struct {
+		tag string
+		ver semver.Version
+	}
+	var candidates []candidate
+	for _, r := range releases {
+		if r.Draft {
+			continue
+		}
+		raw := strings.TrimPrefix(r.TagName, "v")
+		v, parseErr := semver.Parse(raw)
+		if parseErr != nil {
+			continue
+		}
+		if len(v.Pre) > 0 && (v.Pre[0].VersionStr == "alpha" || v.Pre[0].VersionStr == "beta") {
+			continue
+		}
+		candidates = append(candidates, candidate{tag: raw, ver: v})
+	}
+
+	if len(candidates) == 0 {
+		s.Logger.Warn("[resolveMattermostServerVersion] No release found")
+		return s.cachedVersionOrMaster()
+	}
+
+	sort.Slice(candidates, func(i, j int) bool {
+		return candidates[i].ver.GT(candidates[j].ver)
+	})
+
+	version := candidates[0].tag
+	s.Logger.WithField("version", version).Info("[resolveMattermostServerVersion] Resolved latest Mattermost server version")
+
+	s.e2eVersionCacheLock.Lock()
+	s.e2eVersionCache = version
+	s.e2eVersionCacheTime = time.Now()
+	s.e2eVersionCacheLock.Unlock()
+
+	return version
+}
+
+// cachedVersionOrMaster returns the current cached version under lock, or "master" if none is cached.
+func (s *Server) cachedVersionOrMaster() string {
+	s.e2eVersionCacheLock.Lock()
+	v := s.e2eVersionCache
+	s.e2eVersionCacheLock.Unlock()
+	if v != "" {
+		s.Logger.WithField("version", v).Warn("[resolveMattermostServerVersion] Using last known version")
+		return v
+	}
+	return "master"
+}

--- a/server/workflow_run.go
+++ b/server/workflow_run.go
@@ -174,7 +174,7 @@ func (s *Server) handleNightlyE2ETrigger(owner, repoName, branch, sha, triggerEv
 		return
 	}
 
-	instances, err := s.createCMTInstancesForVersion(repoName, instanceType, s.resolveE2EServerVersion(), "nightly")
+	instances, err := s.createCMTInstancesForVersion(repoName, instanceType, s.resolveMattermostServerVersion(), "nightly")
 	if err != nil {
 		logger.WithError(err).Error("Failed to create nightly E2E instances")
 		return


### PR DESCRIPTION
## Problem

Two separate version bugs were affecting how Mattermost servers are provisioned:

### 1. Plugin Spinwicks Used a Rolling `master` Tag

Plugin spinwicks (`mattermost-plugin-*` repositories) have used the hardcoded `master` Docker tag since PR #76.

Because `master` is a rolling tag, two PRs provisioned a week apart could end up running against different Mattermost server versions, resulting in inconsistent test environments.

### 2. Incorrect Release Selection in `resolveE2EServerVersion()`

`resolveE2EServerVersion()` (introduced in PR #87 and used by desktop/mobile E2E tests and nightly runs) selected the first release returned by the GitHub Releases API rather than the highest semantic version.

GitHub orders releases by `published_at`, not by semantic version. As a result, a backported patch release such as `v11.7.5` (published after `v11.8.1`) could be selected instead of the newer version, causing E2E environments to remain on an older release.

## Fix

### Unified Version Resolution

Plugin spinwicks now call `resolveE2EServerVersion()`, ensuring they use the same server version selection logic as all other E2E workflows.

### Correct Semantic Version Selection

`resolveE2EServerVersion()` now:

* Collects all non-draft releases
* Sorts them by semantic version in descending order using `blang/semver`
* Returns the highest available version, including release candidates (RCs)

For example, `11.9.0-rc1` is currently selected because it is the highest available version.

### Automatic Stable Release Promotion

When a stable release becomes available (for example, `11.9.0`), it will automatically take precedence over its corresponding RC on the next cache refresh, with no code changes required.

### Improved Fallback Behavior

If the GitHub API returns an error or no releases are available:

* The resolver now falls back to the last cached version
* It no longer falls back to the rolling `master` tag

## Result

All provisioning flows now consistently resolve to the same server version:

* Plugin spinwicks
* E2E test runs
* Nightly runs
* Push event workflows

**Current resolved version:** `11.9.0-rc1`


```release-note
NONE
```
