### PR TITLE
fix(cmt): use macos-26 and ubuntu-latest for desktop CMT matrix

### DIFF
--- a/server/e2e_dryrun_test.go
+++ b/server/e2e_dryrun_test.go
@@ -437,6 +437,14 @@ func TestDryRun_DesktopCMT(t *testing.T) {
 		environments, ok := matrix["environment"].([]interface{})
 		require.True(t, ok)
 		assert.Len(t, environments, 3, "must have linux, macos, windows")
+		runners := map[string]string{}
+		for _, env := range environments {
+			e := env.(map[string]interface{})
+			runners[e["os"].(string)] = e["runner"].(string)
+		}
+		assert.Equal(t, "ubuntu-latest", runners["linux"])
+		assert.Equal(t, "macos-26", runners["macos"])
+		assert.Equal(t, "windows-2022", runners["windows"])
 
 		servers, ok := matrix["server"].([]interface{})
 		require.True(t, ok)

--- a/server/workflow_run.go
+++ b/server/workflow_run.go
@@ -525,10 +525,12 @@ func buildDesktopCMTMatrixJSON(versions []string, instances []*E2EInstance) (str
 		Server      []cmtServer      `json:"server"`
 	}
 
+	// macos-13 was retired by GitHub (queues forever). macos-26 matches desktop
+	// PR E2E / CMT remapping. ubuntu-latest matches 24.04 (libasound2t64).
 	matrix := desktopCMTMatrix{
 		Environment: []cmtEnvironment{
-			{OS: "linux", Runner: "ubuntu-22.04"},
-			{OS: "macos", Runner: "macos-13"},
+			{OS: "linux", Runner: "ubuntu-latest"},
+			{OS: "macos", Runner: "macos-26"},
 			{OS: "windows", Runner: "windows-2022"},
 		},
 	}


### PR DESCRIPTION
## Summary
- Desktop CMT hardcodes `macos-13` / `ubuntu-22.04` in `buildDesktopCMTMatrixJSON`
- `macos-13` is retired by GitHub, so RC CMT macOS jobs queue forever (seen on [desktop CMT run 30258289129](https://github.com/mattermost/desktop/actions/runs/30258289129))
- Send `macos-26` + `ubuntu-latest` instead, matching desktop PR E2E

## Test plan
- [x] `go test ./server/ -run 'TestDryRun_DesktopCMT|TestE2E' -count=1`
- [ ] Merge, tag `v0.4.16`, bump gitops-platform image ([gitops#78](https://github.com/mattermost/gitops-platform/pull/78))
- [ ] After deploy: re-run Desktop CMT Provisioner and confirm macOS jobs start on `macos-26`

```release-note
NONE
```
