### PR TITLE
config: map mattermost-plugin-docs to its plugin ID

### DIFF
--- a/config/config-matterwick.default.json
+++ b/config/config-matterwick.default.json
@@ -69,7 +69,8 @@
     "TokenEndpoint": "https://matterwick.auth.mattermost.com/oauth/token"
   },
   "PluginRepoToIDMapping": {
-    "mattermost-plugin-boards": "focalboard"
+    "mattermost-plugin-boards": "focalboard",
+    "mattermost-plugin-docs": "com.mattermost.docs"
   },
   "E2ELabel": "E2E/Run",
   "E2EMobileIOSLabel": "E2E/Run-iOS",


### PR DESCRIPTION
## Summary

Adds `mattermost-plugin-docs` → `com.mattermost.docs` to `PluginRepoToIDMapping`, using the mechanism #78 introduced.

Without an entry, `waitForAndInstallPlugin` falls back to trimming the `mattermost-plugin-` prefix:

```go
pluginID, exists := s.Config.PluginRepoToIDMapping[pr.RepoName]
if !exists {
    pluginID = strings.TrimPrefix(pr.RepoName, pluginRepoPrefix)  // → "docs"
}
```

That yields `docs`, but the Docs manifest declares `"id": "com.mattermost.docs"`. `install-url` succeeds either way because it takes a URL, so the **Setup Cloud Test Server** label produces a test server with the plugin installed but **not enabled** — surfacing as the "Plugin Installation Issue / Enable Error" warning on the PR comment.

Same shape as the `mattermost-plugin-boards` → `focalboard` entry: a repo whose plugin ID isn't just its name minus the prefix.

## Context

The producer side is now in place on the Docs repo — [mattermost-plugin-docs#20](https://github.com/mattermost/mattermost-plugin-docs/pull/20) adds the `dist` job that uploads `mattermost-plugin-docs-<sha7>.tar.gz` to the bucket matterwick polls, and the upload is confirmed working. Nothing else in matterwick needs changing: `isPluginRepository` already matches by `mattermost-plugin-` prefix, the bucket is hardcoded to the one being written to, and the `Setup Cloud Test Server` label already exists on that repo.

## Note for whoever deploys

This updates the in-repo default config only. If the deployed `config-matterwick.json` secret does not inherit from this file, it needs the same entry to take effect.

## Test plan

Apply **Setup Cloud Test Server** to a Docs PR and confirm the resulting comment reports the plugin as enabled rather than an Enable Error.


## Release Note
```release-note
NONE
```
