### PR TITLE
Use release-X.Y tags for plugin SpinWick Mattermost images

### DIFF
--- a/server/spinwick_plugin.go
+++ b/server/spinwick_plugin.go
@@ -10,6 +10,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/blang/semver"
 	cloudModel "github.com/mattermost/mattermost-cloud/model"
 	"github.com/mattermost/matterwick/internal/spinwick"
 	"github.com/mattermost/matterwick/model"
@@ -27,6 +28,20 @@ const (
 // isPluginRepository checks if the repository is a plugin repository
 func (s *Server) isPluginRepository(repoName string) bool {
 	return strings.HasPrefix(repoName, pluginRepoPrefix)
+}
+
+// pluginSpinwickImageTag maps a resolved Mattermost version to the Docker tag
+// published on mattermostdevelopment/mattermost-enterprise-edition.
+func pluginSpinwickImageTag(version string) string {
+	version = strings.TrimSpace(version)
+	if version == "" || version == "master" || strings.HasPrefix(version, "release-") {
+		return version
+	}
+	v, err := semver.ParseTolerant(version)
+	if err != nil {
+		return version
+	}
+	return fmt.Sprintf("release-%d.%d", v.Major, v.Minor)
 }
 
 // createPluginSpinWick creates a SpinWick for a plugin repository
@@ -59,9 +74,10 @@ func (s *Server) createPluginSpinWick(pr *model.PullRequest, logger logrus.Field
 
 	logger.Info("No plugin SpinWick found for this PR. Creating a new one.")
 
-	// Create the Mattermost installation using the highest available server version (including RCs)
+	// Create the Mattermost installation using the highest available server version (including RCs).
+	// mattermostdevelopment/ publishes branch tags (release-X.Y), not bare semver.
 	cloudClient := s.CloudClient
-	serverVersion := s.resolveMattermostServerVersion()
+	serverVersion := pluginSpinwickImageTag(s.resolveMattermostServerVersion())
 	logger.WithField("server_version", serverVersion).Info("Resolved Mattermost server version for plugin SpinWick")
 	installationRequest := s.createInstallationRequest(
 		ownerID,

--- a/server/spinwick_plugin.go
+++ b/server/spinwick_plugin.go
@@ -74,7 +74,7 @@ func (s *Server) createPluginSpinWick(pr *model.PullRequest, logger logrus.Field
 
 	logger.Info("No plugin SpinWick found for this PR. Creating a new one.")
 
-	// Create the Mattermost installation using the highest available server version (including RCs).
+	// Create the Mattermost installation using the resolved server version.
 	// mattermostdevelopment/ publishes branch tags (release-X.Y), not bare semver.
 	cloudClient := s.CloudClient
 	serverVersion := pluginSpinwickImageTag(s.resolveMattermostServerVersion())

--- a/server/spinwick_plugin_test.go
+++ b/server/spinwick_plugin_test.go
@@ -304,3 +304,26 @@ func TestConstants(t *testing.T) {
 	assert.Equal(t, "mattermost-plugin-pr-builds", pluginS3Bucket)
 	assert.Equal(t, "us-east-1", pluginS3Region)
 }
+
+func TestPluginSpinwickImageTag(t *testing.T) {
+	tests := []struct {
+		name     string
+		version  string
+		expected string
+	}{
+		{name: "full semver", version: "11.10.0", expected: "release-11.10"},
+		{name: "rc semver", version: "11.10.0-rc3", expected: "release-11.10"},
+		{name: "major.minor", version: "11.10", expected: "release-11.10"},
+		{name: "master", version: "master", expected: "master"},
+		{name: "already release tag", version: "release-11.10", expected: "release-11.10"},
+		{name: "empty", version: "", expected: ""},
+		{name: "whitespace master", version: "  master  ", expected: "master"},
+		{name: "unparseable", version: "latest", expected: "latest"},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			assert.Equal(t, tc.expected, pluginSpinwickImageTag(tc.version))
+		})
+	}
+}


### PR DESCRIPTION
#### Summary
Plugin SpinWicks pull `mattermostdevelopment/mattermost-enterprise-edition`, which publishes branch tags like `release-11.10`, not the bare semver tags (`11.10.0`) returned by `resolveMattermostServerVersion()`. Map resolved versions to `release-X.Y` before creating the Cloud installation so plugin SpinWicks can pull an image that exists. Desktop/mobile E2E paths are unchanged.

#### Release Note
```release-note
NONE
```

Made with [Cursor](https://cursor.com)